### PR TITLE
Add version 1.0.1 to NEWS file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# R6 1.0.1
+
+* First release on CRAN
+* Removed plyr dependency
+
 # R6 1.0
 
 * First release


### PR DESCRIPTION
Wanted to add `print` to the NEWS, and noticed that version 1.0.1 is missing.
