### PR TITLE
Fix trailing newline in default instance print method

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -8,13 +8,15 @@ print.R6 <- function(x, ...) {
       "<", class(x)[1], ">\n",
       "  Public:\n",
       indent(object_summaries(x), 4),
+      "\n",
       sep = ""
     )
 
     if (!is.null(x$private)) {
       cat(
-        "\n  Private:\n",
+        "  Private:\n",
         indent(object_summaries(x$private), 4),
+        "\n",
         sep = ""
       )
     }

--- a/tests/testthat/test-r6class.R
+++ b/tests/testthat/test-r6class.R
@@ -337,3 +337,34 @@ test_that("print method", {
 
   expect_that(print(A), prints_text("^<AC> x = 3 , y = 3 $"))
 })
+
+test_that("default print method has a trailing newline", {
+
+  ## This is kind of hackish, because both capture.output and
+  ## expect_output drop the trailing newline. This function
+  ## does not work in the general case, but it is good enough
+  ## for this test.
+
+  expect_output_n <- function(object) {
+    tmp <- file()
+    on.exit(close(tmp))
+    sink(tmp)
+    print(object)
+    sink(NULL)
+    output <- readChar(tmp, nchar = 10000)
+    last_char <- substr(output, nchar(output), nchar(output))
+    expect_that(last_char, equals("\n"))
+  }
+
+  AC <- R6Class("AC")
+  expect_output_n(print(AC))
+
+  A <- AC$new()
+  expect_output_n(print(A))
+
+  AC <- R6Class("AC", private = list( x = 2 ))
+  expect_output_n(print(AC))
+
+  A <- AC$new()
+  expect_output_n(print(A))
+})


### PR DESCRIPTION
Part of the previous fix in #7 was lost with the merge from #6 at
c590b343abab930d63f29bfcdd2b2d0f84a84f01.

I have also added a test case for this.
