### PR TITLE
Basic support to mimick the use of interface classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: r
 sudo: false
 cache: packages
 
+before_install:
+  - Rscript -e 'install.packages("rmarkdown")'
 notifications:
   email:
     on_success: change

--- a/R/generator_funs.R
+++ b/R/generator_funs.R
@@ -4,6 +4,12 @@ generator_funs$get_inherit <- function() {
   eval(inherit, parent_env, baseenv())
 }
 
+# This function returns the implemented interface superclass object
+generator_funs$get_implement <- function() {
+  # The baseenv() arg speeds up eval a tiny bit
+  eval(implement, parent_env, baseenv())
+}
+
 # This is the $has_private function for a R6ClassGenerator. This copy of it
 # won't run properly; it needs to be copied, and its parent environment set to
 # the generator object environment.
@@ -13,10 +19,12 @@ generator_funs$has_private <- function() {
   inherit <- get_inherit()
   if (!is.null(private_fields) || !is.null(private_methods))
     TRUE
-  else if (is.null(inherit))
+  else if (is.null(inherit) && is.null(implement))
     FALSE
-  else
+  else if (!is.null(inherit))
     inherit$has_private()
+  else
+    implement$has_private()
 }
 
 # This is the $set function for a R6ClassGenerator. This copy of it won't run

--- a/R/interface_utils.R
+++ b/R/interface_utils.R
@@ -1,0 +1,9 @@
+getImplementClassname <- function(x) {
+  # gen <- try(getAnywhere(class(x)[1]), silent = TRUE)
+  gen <- try(get(class(x)[1]), silent = TRUE)
+  if (!inherits(gen, "try-error") &&
+      !is.null(implement <- gen$get_implement())
+  ) {
+    implement$classname
+  }
+}

--- a/R/new.R
+++ b/R/new.R
@@ -4,6 +4,7 @@
 generator_funs$new <- function(...) {
   # Get superclass object -------------------------------------------
   inherit <- get_inherit()
+  implement <- get_implement()
 
   # Some checks on superclass ---------------------------------------
   if (!is.null(inherit)) {
@@ -19,20 +20,21 @@ generator_funs$new <- function(...) {
       merge_vectors(recursive_merge(obj$get_inherit(), which), obj[[which]])
     }
     public_fields  <- merge_vectors(recursive_merge(inherit, "public_fields"),
-                                    public_fields)
+      public_fields)
     private_fields <- merge_vectors(recursive_merge(inherit, "private_fields"),
                                     private_fields)
   }
 
   if (class) {
-    classes <- c(classname, get_superclassnames(inherit), "R6")
+    # classes <- c(classname, get_superclassnames(inherit), "R6")
+    classes <- unique(c(classname, get_superclassnames(inherit),
+      get_superclassnames(implement), "R6"))
   } else {
     classes <- NULL
   }
 
   # Precompute some things ------------------------------------------
   has_priv <- has_private()
-
 
   # Create binding and enclosing environments -----------------------
   if (portable) {
@@ -103,6 +105,69 @@ generator_funs$new <- function(...) {
     public_methods  <- merge_vectors(super_struct$public_methods, public_methods)
     private_methods <- merge_vectors(super_struct$private_methods, private_methods)
     active          <- merge_vectors(super_struct$active, active)
+  }
+
+  # Implemented interface AFTER concrete superclass has been processed as it
+  # "only" defines abstract methods that can be overloaded by this very class
+  # its concrete superclass.
+  # As the actual "crucial" superclass aspects (public and private fields and
+  # methods) have already been processed, this shouldn't break any of the
+  # current implementation aspects.
+  if (!is.null(implement)) {
+    if (portable) {
+      # Set up the superclass objects
+      super_struct <- create_super_env(implement, public_bind_env,
+        private_bind_env, portable = TRUE)
+    } else {
+      # Set up the superclass objects
+    super_struct <- create_super_env(implement, public_bind_env, portable = FALSE)
+    }
+
+    # Cache decoupled state of env or interface superclass for sanity checks
+    # (see below)
+    implement_super_struct <- as.list(super_struct)
+
+    enclos_env$super <- super_struct$bind_env
+
+    # Merge this level's methods over the superclass methods
+    public_methods  <- merge_vectors(super_struct$public_methods, public_methods)
+    private_methods <- merge_vectors(super_struct$private_methods, private_methods)
+    active          <- merge_vectors(super_struct$active, active)
+
+    # Note:
+    # If running the same code for `implement` as for `inherit` interferes with
+    # current behavior of `super_struct` and associated aspects the following
+    # would also be an alternative.
+    # As we only need a check of the public methods here in order to mimick the
+    # concept/behavior of interfaces, the following should suffice:
+    # implement_super_struct <- implement
+
+    # Sanity checks
+    # Throw an error in case neither the superclass nor the actual class
+    # overloads/implements any of the abstract public methods defined by the
+    # interface superclass as I think this would be a violation of the concept
+    # of a class IMPLEMENTING an interface from an OOD perspective.
+    # Note:
+    # The gsub part is only necessary due to the fact that the `clone` method
+    # features this suffix --> a possible minor inconsistency with regard to
+    # remaining methods such as `has_private` etc.?
+
+    public_methods_interface <- implement_super_struct$public_methods
+    interface_funs <- setdiff(names(public_methods_interface),
+      gsub("_method$", "", names(generator_funs)))
+    if (length(interface_funs)) {
+      err_list <- unlist(sapply(interface_funs, function(fun) {
+        if (identical(
+          body(public_methods_interface[[fun]]),
+          body(public_methods[[fun]])
+        )) {
+          sprintf("Non-implemented interface method: %s", fun)
+        }
+      }))
+      if (length(err_list)) {
+        stop(paste(c("\n", err_list), collapse = "\n"))
+      }
+    }
   }
 
   # Copy objects to public bind environment -------------------------

--- a/R/print.R
+++ b/R/print.R
@@ -7,6 +7,18 @@ format.R6 <- function(x, ...) {
 
     # If there's another class besides first class and R6
     classes <- setdiff(class(x), "R6")
+    if (!is.null(name <- getImplementClassname(x))) {
+    # --> doesn't work for all scenarios as `get(class(x)[1])` sometimes
+    # returns an error
+      ret <- c(ret, paste0("  Implements interface: <", name, ">"))
+      # Update classes for "actual inherits part"
+      classes <- classes[classes != name]
+    } else if (any(idx <- grepl("^I", classes))) {
+      ret <- c(ret, paste0("  Implements interface: <", classes[idx], ">"))
+      # Update classes for "actual inherits part"
+      classes <- classes[!idx]
+    }
+
     if (length(classes) >= 2) {
       ret <- c(ret, paste0("  Inherits from: <", classes[2], ">"))
     }
@@ -44,6 +56,10 @@ format.R6ClassGenerator <- function(x, ...) {
 
   if (!is.null(x$inherit)) {
     ret <- c(ret, paste0("  Inherits from: <", deparse(x$inherit), ">"))
+  }
+
+  if (!is.null(x$implement)) {
+    ret <- c(ret, paste0("  Implements interface: <", deparse(x$implement), ">"))
   }
 
   ret <- c(ret,

--- a/R/r6_class.R
+++ b/R/r6_class.R
@@ -123,6 +123,13 @@
 #' @param cloneable If \code{TRUE} (the default), the generated objects will
 #'   have method named \code{$clone}, which makes a copy of the object.
 #' @param lock Deprecated as of version 2.1; use \code{lock_class} instead.
+#' @param implement A R6ClassGenerator object to inherit from which represents
+#'   an interface class; this is very similar to argument \code{inherit} with
+#'   the subtle difference that such objects merely mimick abstract classes that
+#'   only define abstract methods and must not contain \strong{any} data fields.
+#'   The main benefit is being able to write code that fits the \emph{SOLID principles
+#'   of object-oriented design}
+#'   (\url{https://en.wikipedia.org/wiki/SOLID_%28object-oriented_design%29}).
 #' @examples
 #' # A queue ---------------------------------------------------------
 #' Queue <- R6Class("Queue",
@@ -470,7 +477,8 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
                                 inherit = NULL, lock_objects = TRUE,
                                 class = TRUE, portable = TRUE,
                                 lock_class = FALSE, cloneable = TRUE,
-                                parent_env = parent.frame(), lock) {
+                                parent_env = parent.frame(), lock,
+                                implement = NULL) {
 
   if (!all_named(public) || !all_named(private) || !all_named(active))
     stop("All elements of public, private, and active must be named.")
@@ -530,6 +538,11 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
   # Capture the unevaluated expression for the superclass; when evaluated in
   # the parent_env, it should return the superclass object.
   generator$inherit <- substitute(inherit)
+
+  # Capture the unevaluated expression for the interface implementation
+  # superclass; when evaluated in the parent_env, it should return the
+  # superclass object.
+  generator$implement <- substitute(implement)
 
   # Names of methods for which to enable debugging
   generator$debug_names <- character(0)

--- a/R/r6_class.R
+++ b/R/r6_class.R
@@ -127,9 +127,9 @@
 #'   an interface class; this is very similar to argument \code{inherit} with
 #'   the subtle difference that such objects merely mimick abstract classes that
 #'   only define abstract methods and must not contain \strong{any} data fields.
-#'   The main benefit is being able to write code that fits the \emph{SOLID principles
-#'   of object-oriented design}
-#'   (\url{https://en.wikipedia.org/wiki/SOLID_%28object-oriented_design%29}).
+#'   The main benefit is being able to write code that fits the \emph{SOLID
+#'   principles of object-oriented design}
+#'   (\url{https://en.wikipedia.org/wiki/SOLID_\%28object-oriented_design\%29}).
 #' @examples
 #' # A queue ---------------------------------------------------------
 #' Queue <- R6Class("Queue",

--- a/man/R6Class.Rd
+++ b/man/R6Class.Rd
@@ -8,7 +8,7 @@
 R6Class(classname = NULL, public = list(), private = NULL,
   active = NULL, inherit = NULL, lock_objects = TRUE, class = TRUE,
   portable = TRUE, lock_class = FALSE, cloneable = TRUE,
-  parent_env = parent.frame(), lock)
+  parent_env = parent.frame(), lock, implement = NULL)
 }
 \arguments{
 \item{classname}{Name of the class. The class name is useful primarily for S3
@@ -51,6 +51,14 @@ have method named \code{$clone}, which makes a copy of the object.}
 objects.}
 
 \item{lock}{Deprecated as of version 2.1; use \code{lock_class} instead.}
+
+\item{implement}{A R6ClassGenerator object to inherit from which represents
+an interface class; this is very similar to argument \code{inherit} with
+the subtle difference that such objects merely mimick abstract classes that
+only define abstract methods and must not contain \strong{any} data fields.
+The main benefit is being able to write code that fits the \emph{SOLID
+principles of object-oriented design}
+(\url{https://en.wikipedia.org/wiki/SOLID_\%28object-oriented_design\%29}).}
 }
 \description{
 R6 objects are essentially environments, structured in a way that makes them

--- a/tests/testthat/test-interfaces.R
+++ b/tests/testthat/test-interfaces.R
@@ -1,0 +1,107 @@
+context("interfaces")
+
+test_that("Test generator object structure", {
+  IFoo <- R6Class("IFoo",
+    public = list(foo = function() stop("I'm the inferace method"))
+  )
+  Foo <- R6Class("Foo", implement = IFoo,
+    public = list(foo = function(n = 1) private$x[1:n]),
+    private = list(x = letters)
+  )
+  expect_true(exists("implement", Foo))
+  expect_true(identical(Foo$implement, as.name("IFoo")))
+  expect_true(exists("get_implement", Foo))
+  expect_true(identical(Foo$get_implement(), IFoo))
+})
+
+test_that("Interface implemented correctly", {
+  IFoo <- R6Class("IFoo",
+    public = list(foo = function() stop("I'm the inferace method"))
+  )
+  Foo <- R6Class("Foo", implement = IFoo,
+    public = list(foo = function(n = 1) private$x[1:n]),
+    private = list(x = letters)
+  )
+  expect_is(inst <- Foo$new(), "Foo")
+  expect_true(inherits(inst, "IFoo"))
+})
+
+test_that("Interface implemented incorrectly", {
+  IFoo <- R6Class("IFoo",
+    public = list(foo = function() stop("I'm the inferace method"))
+  )
+  Foo <- R6Class("Foo", implement = IFoo,
+    private = list(x = letters)
+  )
+  expect_error(Foo$new(), "Non-implemented interface method: foo")
+})
+
+test_that("Interface and standard inheritance", {
+  IFoo <- R6Class("IFoo",
+    public = list(foo = function() stop("I'm the inferace method"))
+  )
+  BaseClass <- R6Class("BaseClass",
+    public = list(foo = function(n = 1) private$x[1:n])
+  )
+  Foo <- R6Class("Foo", implement = IFoo, inherit = BaseClass,
+    private = list(x = letters)
+  )
+  expect_is(inst <- Foo$new(), "Foo")
+  expect_true(inherits(inst, "BaseClass"))
+  expect_true(inherits(inst, "IFoo"))
+
+  expect_identical(inst$foo(3), letters[1:3])
+})
+
+context("interfaces: print method")
+
+test_that("Test print method: standard inheritance", {
+  skip("Manual only. Print helper `getImplementClassname` still off with
+    respect to enclosing frames")
+  IFoo <- R6Class("IFoo",
+    public = list(foo = function() stop("I'm the inferace method"))
+  )
+  Foo <- R6Class("Foo", inherit = IFoo,
+    public = list(foo = function(n = 1) private$x[1:n]),
+    private = list(x = letters)
+  )
+  expect_true(any(grepl("Inherits from: <IFoo>", capture.output(Foo))))
+
+  inst <- Foo$new()
+  print(capture.output(inst))
+  expect_true(any(grepl("Inherits from: <IFoo>", capture.output(inst))))
+})
+
+test_that("Test print method: interface implementation", {
+  # skip("Manual only. Print helper `getImplementClassname` still off with
+  #   respect to enclosing frames")
+  IFoo <- R6Class("IFoo",
+    public = list(foo = function() stop("I'm the inferace method"))
+  )
+  Foo <- R6Class("Foo", implement = IFoo,
+    public = list(foo = function(n = 1) private$x[1:n]),
+    private = list(x = letters)
+  )
+  expect_true(any(grepl("Implements interface: <IFoo>", capture.output(Foo))))
+
+  inst <- Foo$new()
+  expect_true(any(grepl("Implements interface: <IFoo>", capture.output(inst))))
+})
+
+test_that("Test print method: interface and standard inheritance", {
+  IFoo <- R6Class("IFoo",
+    public = list(foo = function() stop("I'm the inferace method"))
+  )
+  BaseClass <- R6Class("BaseClass",
+    public = list(foo = function(n = 1) private$x[1:n])
+  )
+  Foo <- R6Class("Foo", implement = IFoo, inherit = BaseClass,
+    private = list(x = letters)
+  )
+  expect_true(any(grepl("Inherits from: <BaseClass>", capture.output(Foo))))
+  expect_true(any(grepl("Implements interface: <IFoo>", capture.output(Foo))))
+
+  inst <- Foo$new()
+  expect_true(any(grepl("Inherits from: <BaseClass>", capture.output(inst))))
+  expect_true(any(grepl("Implements interface: <IFoo>", capture.output(inst))))
+})


### PR DESCRIPTION
Hi Winston,

I kindly ask you to consider accepting this pull request. It is associated with my addition to #9  yesterday.

I figured that I actually don't really need multiple inheritance but just a way to distinguish between 
1.  "interface classes" to mimicking interfaces/abstract classes. These only define public abstract methods that a concrete class needs to implement, so a simple "check if method `xy` is implementend in `$new()` would really kind of suffice.
2. "concrete classes" for **actual** inheritance

I'm aware that I might be pushing `R6`'s intended use and R's class inheritance mechanism a bit, but I personally like the [SOLID principles](https://en.wikipedia.org/wiki/SOLID_%28object-oriented_design%29) in general and that of _interfaces_ in particular very much. I think following those simply makes for better code and IMO even "just" prototyping OO stuff in R with R6 shoudn't be an exception.

This is my first substantial pull request for another person's codebase. I tried to be both stick to your style and be thorough (updated doc and unit tests), but probably something still slipped through the cracks ;-) So please don't hesitate to contact me in case there's something else that I can do!

Note:
I noticed that my modification of the `print` method is a bit of in cases where `get(class(x)[1])` fails in `getImplementClassname` (script `R/interface_utils.R`). It worked upon manual execution of `test_that()`, but not when the file was sourced.
