### PR TITLE
new() inherits argument list from initialize()

### DIFF
--- a/R/new.R
+++ b/R/new.R
@@ -1,7 +1,7 @@
 # This is the $new function for a R6ClassGenerator. This copy of it won't run
 # properly; it needs to be copied, and its parent environment set to the
 # generator object environment.
-generator_funs$new <- function(...) {
+generator_funs$new_dots <- function(...) {
   # Get superclass object -------------------------------------------
   inherit <- get_inherit()
 

--- a/R/new.R
+++ b/R/new.R
@@ -1,7 +1,7 @@
 # This is the $new function for a R6ClassGenerator. This copy of it won't run
 # properly; it needs to be copied, and its parent environment set to the
 # generator object environment.
-generator_funs$new_dots <- function(...) {
+generator_funs$.new_dots <- function(...) {
   # Get superclass object -------------------------------------------
   inherit <- get_inherit()
 

--- a/R/r6_class.R
+++ b/R/r6_class.R
@@ -510,7 +510,7 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
 
   # Add a "new" function that wraps ".new_dots"
   generator_funs <- generator_funs
-  generator_funs$new <- wrap_dots_fun(".new_dots", public$initialize, generator)
+  generator_funs$new <- wrap_dots_fun(generator_funs$.new_dots, ".new_dots", public$initialize)
 
   # Copy the generator functions into the generator env.
   list2env2(generator_funs, generator)
@@ -545,9 +545,9 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
   generator
 })
 
-wrap_dots_fun <- function(dots_fun_name, arglist_fun, envir) {
-  if (is.null(arglist_fun)) {
-    arglist_fun <- function(...) NULL
+wrap_dots_fun <- function(dots_fun, dots_fun_name, arglist_fun) {
+  if (is.null(arglist_fun) || identical(formals(arglist_fun), as.pairlist(alist(... = )))) {
+    return(dots_fun)
   }
 
   my_formals <- formals(arglist_fun)
@@ -561,7 +561,7 @@ wrap_dots_fun <- function(dots_fun_name, arglist_fun, envir) {
     }
   ))
 
-  environment(new_fun) <- envir
+  environment(new_fun) <- environment(dots_fun)
   formals(new_fun) <- my_formals
 
   new_fun

--- a/R/r6_class.R
+++ b/R/r6_class.R
@@ -548,7 +548,7 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
 
 wrap_dots_fun <- function(dots_fun, arglist_fun) {
   if (is.null(arglist_fun)) {
-    return(dots_fun)
+    arglist_fun <- function() NULL
   }
 
   my_formals <- formals(arglist_fun)

--- a/R/r6_class.R
+++ b/R/r6_class.R
@@ -508,10 +508,9 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
   # Set the generator functions to eval in the generator environment
   generator_funs <- assign_func_envs(generator_funs, generator)
 
-  # Add a "new" function that wraps "new_dots"
+  # Add a "new" function that wraps ".new_dots"
   generator_funs <- generator_funs
-  generator_funs$new <- wrap_dots_fun(generator_funs$new_dots, public$initialize)
-  generator_funs$new_dots <- NULL
+  generator_funs$new <- wrap_dots_fun(".new_dots", public$initialize, generator)
 
   # Copy the generator functions into the generator env.
   list2env2(generator_funs, generator)
@@ -546,7 +545,7 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
   generator
 })
 
-wrap_dots_fun <- function(dots_fun, arglist_fun) {
+wrap_dots_fun <- function(dots_fun_name, arglist_fun, envir) {
   if (is.null(arglist_fun)) {
     arglist_fun <- function(...) NULL
   }
@@ -554,16 +553,15 @@ wrap_dots_fun <- function(dots_fun, arglist_fun) {
   my_formals <- formals(arglist_fun)
   my_formals_names <- lapply(names(my_formals), as.name)
   names(my_formals_names) <- names(my_formals)
-  dots_fun_call <- as.call(c(quote(dots_fun), my_formals_names))
+  dots_fun_call <- as.call(c(as.name(dots_fun_name), my_formals_names))
 
   new_fun <- eval(bquote(
     function() {
-      dots_fun <- .(dots_fun)
       .(dots_fun_call)
     }
   ))
 
-  environment(new_fun) <- environment(dots_fun)
+  environment(new_fun) <- envir
   formals(new_fun) <- my_formals
 
   new_fun

--- a/R/r6_class.R
+++ b/R/r6_class.R
@@ -548,7 +548,7 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
 
 wrap_dots_fun <- function(dots_fun, arglist_fun) {
   if (is.null(arglist_fun)) {
-    arglist_fun <- function() NULL
+    arglist_fun <- function(...) NULL
   }
 
   my_formals <- formals(arglist_fun)

--- a/tests/testthat/test-initialize.R
+++ b/tests/testthat/test-initialize.R
@@ -24,3 +24,9 @@ test_that("initializer with dots", {
   Initializer <- R6Class("Initializer", public = list(initialize = function(a = "", ..., b) NULL))
   expect_identical(formals(Initializer$new), as.pairlist(alist(a = "", ... = , b = )))
 })
+
+test_that("inherited initializer", {
+  A <- R6Class("A", public = list(initialize = function(a = "", ..., b) NULL))
+  B <- R6Class("B", inherit = A)
+  expect_identical(formals(B$new), formals(A$new))
+})

--- a/tests/testthat/test-initialize.R
+++ b/tests/testthat/test-initialize.R
@@ -2,7 +2,10 @@ context("initialize")
 
 test_that("no initializer", {
   NoInitializer <- R6Class("NoInitializer")
-  expect_null(formals(NoInitializer$new))
+
+  # Absence of initializer means we might use an inherited initializer,
+  # but we don't know its interface at the time the class is created (#12).
+  expect_identical(formals(NoInitializer$new), as.pairlist(alist(... = )))
 })
 
 test_that("empty initializer", {
@@ -28,5 +31,5 @@ test_that("initializer with dots", {
 test_that("inherited initializer", {
   A <- R6Class("A", public = list(initialize = function(a = "", ..., b) NULL))
   B <- R6Class("B", inherit = A)
-  expect_identical(formals(B$new), formals(A$new))
+  expect_identical(formals(B$new), as.pairlist(alist(... = )))
 })

--- a/tests/testthat/test-initialize.R
+++ b/tests/testthat/test-initialize.R
@@ -1,0 +1,26 @@
+context("initialize")
+
+test_that("no initializer", {
+  NoInitializer <- R6Class("NoInitializer")
+  expect_null(formals(NoInitializer$new))
+})
+
+test_that("empty initializer", {
+  EmptyInitializer <- R6Class("EmptyInitializer", public = list(initialize = function() NULL))
+  expect_null(formals(EmptyInitializer$new))
+})
+
+test_that("initializer with args", {
+  Initializer <- R6Class("Initializer", public = list(initialize = function(a) NULL))
+  expect_identical(formals(Initializer$new), as.pairlist(alist(a = )))
+})
+
+test_that("initializer with args and defaults", {
+  Initializer <- R6Class("Initializer", public = list(initialize = function(a = "", b) NULL))
+  expect_identical(formals(Initializer$new), as.pairlist(alist(a = "", b = )))
+})
+
+test_that("initializer with dots", {
+  Initializer <- R6Class("Initializer", public = list(initialize = function(a = "", ..., b) NULL))
+  expect_identical(formals(Initializer$new), as.pairlist(alist(a = "", ... = , b = )))
+})


### PR DESCRIPTION
Fixes #47: The original boilerplate for new() is available as new_dots(). ~~If a class has an initialize() method,~~ new() is created as a function with proper argument list, which forwards to a local copy of new_dots().

All tests pass without modification.

Compared to #63, this also works when the new() method is assigned to a variable, a use case I've encountered recently.