### PR TITLE
Fix subsubclass super

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: R6
 Title: Classes with Reference Semantics
-Version: 2.2.2.9000
+Version: 2.2.2.9001
 Authors@R: person("Winston", "Chang", role = c("aut", "cre"), email = "winston@stdout.org")
 Description: Creates classes with reference semantics, similar to R's built-in
     reference classes. Compared to reference classes, R6 classes are simpler

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
-R6 2.2.2.9000
+R6 2.2.2.9001
 ========
+
+* Fixed [#155](https://github.com/r-lib/R6/issues/155): In some cases, a cloned object's methods could refer to the wrong `super` object. ([#156](https://github.com/r-lib/R6/pull/156))
+
+* Fixed [#94](https://github.com/r-lib/R6/issues/94), [#133](https://github.com/r-lib/R6/issues/133): When cloning an object which contained a function that is *not* a method, the corresponding function in the new object would have its environment changed, as though it were a method. Now it no longer has a changed environment. ([#156](https://github.com/r-lib/R6/pull/156))
 
 * Fixed [#121](https://github.com/r-lib/R6/issues/121): If a `finalize` method was present, it would prevent objects passed to `initialize` from getting GC'd.
 

--- a/R/clone.R
+++ b/R/clone.R
@@ -29,84 +29,48 @@ generator_funs$clone_method <- function(deep = FALSE) {
     list2env(x, envir)
   }
 
-  clone_super <- function(old_enclos_env, new_enclos_env, public_bind_env,
-                          has_private, private_bind_env)
-  {
-    old_super_bind_env <- old_enclos_env$super
-    if (is.null(old_super_bind_env))
-      return()
+  # ---------------------------------------------------------------------------
+  # Create representation of the old object
+  # ---------------------------------------------------------------------------
+  old <- list(
+    list(
+      enclosing = .subset2(self, ".__enclos_env__"),
+      binding   = self,      # AKA the public binding environment
+      private   = NULL
+    )
+  )
 
-    # Copy all the methods from the old super binding env to the new one, and
-    # set their enclosing env to a new one.
-    super_copies <- as.list.environment(old_super_bind_env, all.names = TRUE)
-    super_copies <- super_copies[setdiff(names(super_copies), ".__enclos_env__")]
-
-    # Degenerate case: super env is empty
-    if (length(super_copies) == 0) {
-      new_enclos_env$super <- new.env(parent = emptyenv(), hash = FALSE)
-      return()
-    }
-
-    # Get the enclosing env for the super object. Note that this is the
-    # enclosing env only for methods declared for this level of super object --
-    # if this super object has inherited methods from its super object, then
-    # those methods will have a different environment. (#119)
-    old_super_enclos_env <- old_super_bind_env$.__enclos_env__
-
-    # Create new super enclos env and populate with self and private.
-    new_super_enclos_env <- new.env(parent = parent.env(old_super_enclos_env),
-                                    hash = FALSE)
-    new_super_enclos_env$self <- public_bind_env
-    if (has_private)
-      new_super_enclos_env$private <- private_bind_env
-
-    new_super_bind_env <- new.env(parent = emptyenv(), hash = FALSE)
-    new_super_bind_env$.__enclos_env__ <- new_super_enclos_env
-
-    # Fix up environments for methods
-    super_copies <- assign_func_envs(super_copies, new_super_enclos_env)
-
-    # Separate active from non-active items
-    active_idx <- vapply(names(super_copies), bindingIsActive, env = old_super_bind_env,
-                         TRUE)
-    active_copies     <- super_copies[active_idx]
-    non_active_copies <- super_copies[!active_idx]
-
-    # Copy over items
-    list2env2(non_active_copies, new_super_bind_env)
-
-    if (length(active_copies) > 0) {
-      for (name in names(active_copies)) {
-        makeActiveBinding(name, active_copies[[name]], new_super_bind_env)
-      }
-    }
-
-    new_enclos_env$super <- new_super_bind_env
-
-    # Recurse
-    clone_super(old_super_enclos_env, new_super_enclos_env, public_bind_env,
-                has_private, private_bind_env)
-  }
-
-  # ------------------------------------------------------------------
-
-  old_enclos_env <- .subset2(self, ".__enclos_env__")
-  if (!is.environment(old_enclos_env)) {
+  if (!is.environment(old[[1]]$enclosing)) {
     stop("clone() must be called from an R6 object.")
   }
 
-  old_public_bind_env <- self
-  old_private_bind_env <- old_enclos_env$private
-  has_private <- !is.null(old_private_bind_env)
+  old[[1]]$private <- old[[1]]$enclosing$private
+  has_private <- !is.null(old[[1]]$private)
 
   # Figure out if we're in a portable class object
-  portable <- !identical(old_public_bind_env, old_enclos_env)
+  portable <- !identical(old[[1]]$binding, old[[1]]$enclosing)
+
+  # Traverse the super binding and enclosing environments, and add them to the
+  # list.
+  i <- 1
+  while (TRUE) {
+    if (is.null(old[[i]]$enclosing$super)) {
+      break
+    }
+
+    old[[i+1]] <- list(
+      binding   = old[[i]]$enclosing$super,
+      enclosing = old[[i]]$enclosing$super$.__enclos_env__
+    )
+
+    i <- i + 1
+  }
 
   # Set up stuff for deep clones
   if (deep) {
-    if (has_private && is.function(old_private_bind_env$deep_clone)) {
+    if (has_private && is.function(old[[1]]$private$deep_clone)) {
       # Get private$deep_clone, if available.
-      deep_clone <- old_private_bind_env$deep_clone
+      deep_clone <- old[[1]]$private$deep_clone
     } else {
       # If there's no private$deep_clone, then this default function will copy
       # fields that are R6 objects.
@@ -120,107 +84,193 @@ generator_funs$clone_method <- function(deep = FALSE) {
     }
   }
 
-  # Create the new binding and enclosing environments
-  if (portable) {
-    if (has_private) {
-      private_bind_env <- new.env(emptyenv(), hash = FALSE)
-    }
-    public_bind_env <- new.env(emptyenv(), hash = FALSE)
-    new_enclos_env <- new.env(parent.env(old_enclos_env), hash = FALSE)
+  # ---------------------------------------------------------------------------
+  # Create representation of the new object
+  # ---------------------------------------------------------------------------
 
-  } else {
-    if (has_private) {
-      private_bind_env <- new.env(parent.env(old_private_bind_env), hash = FALSE)
-      public_bind_env <- new.env(private_bind_env, hash = FALSE)
+  # The object representation is made up of a list of "slices". Each slice
+  # represents one level of inheritance. The first slice is somewhat different
+  # from subsequent ones. The later ones are superclass slices. They do not
+  # have a separate `private` environment.
+
+  # Create the first slice. This one is different from the others.
+  make_first_new_slice <- function(old_slice, portable) {
+    new_slice <- list(
+      enclosing = NULL,
+      binding   = NULL
+    )
+
+    has_private <- !is.null(old_slice$private)
+
+    if (portable) {
+      enclosing_parent <- parent.env(old_slice$enclosing)
+      binding_parent   <- emptyenv()
+
+      if (has_private) {
+        private_parent   <- emptyenv()
+        new_slice$private <- new.env(private_parent, hash = FALSE)
+      }
+      new_slice$binding   <- new.env(binding_parent,   hash = FALSE)
+      new_slice$enclosing <- new.env(enclosing_parent, hash = FALSE)
+
     } else {
-      public_bind_env <- new.env(parent.env(old_public_bind_env), hash = FALSE)
+      if (has_private) {
+        private_parent   <- parent.env(old_slice$private)
+        new_slice$private <- new.env(private_parent, hash = FALSE)
+
+        binding_parent   <- new_slice$private
+        new_slice$binding <- new.env(binding_parent, hash = FALSE)
+
+      } else {
+        binding_parent <- parent.env(old_slice$binding)
+        new_slice$binding <- new.env(binding_parent, hash = FALSE)
+      }
+
+      new_slice$enclosing <- new_slice$binding
     }
-    new_enclos_env <- public_bind_env
+
+    # Set up self, private, and .__enclos_env__
+    new_slice$enclosing$self <- new_slice$binding
+    if (has_private) {
+      new_slice$enclosing$private <- new_slice$private
+    }
+    new_slice$binding$.__enclos_env__ <- new_slice$enclosing
+
+    new_slice
   }
 
 
-  # Copy members ----------------------------------------------------
+  # This creates a slice other than the first one.
+  make_new_slice <- function(old_slice, self, private) {
+    enclosing_parent <- parent.env(old[[i]]$enclosing)
+    binding_parent   <- parent.env(old[[i]]$binding)
 
-  # Copy the old objects, fix up method environments, and put them into the
-  # new binding environment.
-  public_copies <- as.list.environment(old_public_bind_env, all.names = TRUE)
-  # If non-portable, `self` will be there; make sure not to copy it.
-  if (!portable) {
-    public_copies$self <- NULL
-  }
-  # Don't copy .__enclos_env__
-  public_copies <- public_copies[setdiff(names(public_copies), ".__enclos_env__")]
-  public_copies <- assign_func_envs(public_copies, new_enclos_env)
+    enclosing <- new.env(enclosing_parent, hash = FALSE)
+    binding   <- new.env(binding_parent,   hash = FALSE)
 
-  # Separate active and non-active bindings
-  active_idx <- vapply(names(public_copies), bindingIsActive, env = old_public_bind_env,
-                       logical(1))
-  active_copies <- public_copies[active_idx]
-  public_copies <- public_copies[!active_idx]
+    enclosing$self <- self
+    if (!is.null(private)) {
+      enclosing$private <- private
+    }
 
-  if (deep) {
-    public_copies <- mapply(deep_clone, names(public_copies), public_copies,
-                            SIMPLIFY = FALSE)
+    binding$.__enclos_env__ <- enclosing
+
+    list(
+      enclosing = enclosing,
+      binding = binding
+    )
   }
 
-  # Copy in public and active bindings
-  list2env2(public_copies, public_bind_env)
+  new <- list(
+    make_first_new_slice(old[[1]], portable)
+  )
 
-  if (length(active_copies) > 0) {
-    for (name in names(active_copies)) {
-      makeActiveBinding(name, active_copies[[name]], public_bind_env)
+  # Mirror the super environments from the old object
+  if (length(old) > 1) {
+    for (i in seq(2, length(old))) {
+      new[[i]] <- make_new_slice(
+        old[[i]],
+        new[[1]]$binding,
+        new[[1]]$private
+      )
+    }
+
+    # A second pass to add in the `super` to each enclosing environment.
+    for (i in seq(1, length(old)-1)) {
+      new[[i]]$enclosing$super <- new[[i+1]]$binding
     }
   }
 
-  # Copy private members
-  if (has_private) {
-    private_copies <- as.list.environment(old_private_bind_env, all.names = TRUE)
+  # ---------------------------------------------------------------------------
+  # Copy members from old to new
+  # ---------------------------------------------------------------------------
+  copy_slice <- function(old_slice, new_slice) {
+    # Copy the old objects, fix up method environments, and put them into the
+    # new binding environment.
+    binding_copies <- as.list.environment(old_slice$binding, all.names = TRUE)
+
+    # Don't copy self, private, super, or .__enclos_env__
+    binding_copies <- binding_copies[
+      setdiff(names(binding_copies), c("self", "private", "super", ".__enclos_env__"))
+    ]
+
+    # TODO: Fix this up to iterate over super envs
+    binding_copies <- assign_func_envs(binding_copies, new_slice$enclosing)
+
+    # Separate active and non-active bindings
+    active_idx <- vapply(
+      names(binding_copies),
+      bindingIsActive,
+      env = old_slice$binding,
+      TRUE
+    )
+    active_copies  <- binding_copies[active_idx]
+    binding_copies <- binding_copies[!active_idx]
+
     if (deep) {
-      private_copies <- mapply(deep_clone, names(private_copies), private_copies,
-                               SIMPLIFY = FALSE)
+      binding_copies <- mapply(
+        deep_clone,
+        names(binding_copies),
+        binding_copies,
+        SIMPLIFY = FALSE
+      )
     }
-    private_copies <- assign_func_envs(private_copies, new_enclos_env)
-    list2env2(private_copies, private_bind_env)
+
+    # Copy in public and active bindings
+    list2env2(binding_copies, new_slice$binding)
+
+    if (length(active_copies) > 0) {
+      for (name in names(active_copies)) {
+        makeActiveBinding(name, active_copies[[name]], new_slice$binding)
+      }
+    }
+
+    # Copy private members
+    if (!is.null(old_slice$private)) {
+      private_copies <- as.list.environment(old_slice$private, all.names = TRUE)
+      if (deep) {
+        private_copies <- mapply(
+          deep_clone,
+          names(private_copies),
+          private_copies,
+          SIMPLIFY = FALSE
+        )
+      }
+      private_copies <- assign_func_envs(private_copies, new_slice$enclosing)
+      list2env2(private_copies, new_slice$private)
+    }
   }
 
-  # Clone super object -------------------------------------------
-  clone_super(old_enclos_env, new_enclos_env, public_bind_env, has_private,
-              private_bind_env)
+  for (i in seq_along(old)) {
+    # This works because the objects in new are reference objects
+    copy_slice(old[[i]], new[[i]])
+  }
 
-  # Add refs to other environments in the object --------------------
-  public_bind_env$`.__enclos_env__` <- new_enclos_env
 
-  # Add self and (optional) private pointer ---------------------------
-  new_enclos_env$self <- public_bind_env
-  if (has_private)
-    new_enclos_env$private <- private_bind_env
-
-  class(public_bind_env) <- class(old_public_bind_env)
+  class(new[[1]]$binding) <- class(old[[1]]$binding)
 
   # Lock --------------------------------------------------------------
   # Copy locked state of environment
-  if (environmentIsLocked(old_public_bind_env)) {
-    lockEnvironment(public_bind_env)
+  if (environmentIsLocked(old[[1]]$binding)) {
+    lockEnvironment(new[[1]]$binding)
   }
-  if (has_private && environmentIsLocked(old_private_bind_env)) {
-    lockEnvironment(private_bind_env)
+  if (has_private && environmentIsLocked(old[[1]]$private)) {
+    lockEnvironment(new[[1]]$private)
   }
 
   # Always lock methods
-  # We inspect the names in public_copies instead public_bind_env, because
-  # ls() is so slow for environments. R 3.2.0 introduced the sorted=FALSE
-  # option, which makes ls() much faster, so at some point we'll be able to
-  # switch to that.
-  for (name in names(public_copies)) {
-    if (is.function(.subset2(public_bind_env, name)))
-      lockBinding(name, public_bind_env)
+  # R 3.2.0 introduced the sorted=FALSE option, which makes ls() much faster,
+  # so at some point we'll be able to switch to that.
+  for (name in ls(new[[1]]$binding)) {
+    if (is.function(.subset2(new[[1]]$binding, name)))
+      lockBinding(name, new[[1]]$binding)
   }
   if (has_private) {
-    for (name in names(private_copies)) {
-      if (is.function(private_bind_env[[name]]))
-        lockBinding(name, private_bind_env)
+    for (name in names(new[[1]]$private)) {
+      if (is.function(new[[1]]$private[[name]]))
+        lockBinding(name, new[[1]]$private)
     }
   }
 
-  public_bind_env
+  new[[1]]$binding
 }

--- a/tests/testthat/test-clone.R
+++ b/tests/testthat/test-clone.R
@@ -716,3 +716,57 @@ test_that("Deep cloning non-portable classes", {
   expect_identical(a2$x, 2)
   expect_identical(a2$self, a2)
 })
+
+
+
+test_that("Cloning with functions that are not methods", {
+  x <- 0
+  local_x1 <- local({
+    x <- 1
+    function() x
+  })
+
+  AC <- R6Class("AC",
+    public = list(
+      f = NULL
+    )
+  )
+
+  a <- AC$new()
+  a$f <- local_x1
+  expect_identical(a$f(), 1)
+
+  a2 <- a$clone()
+  expect_identical(a2$f(), 1)
+
+  # Clone of a clone
+  a3 <- a$clone()
+  expect_identical(a3$f(), 1)
+
+  # ==== With inheritance ====
+  local_x2 <- local({
+    x <- 2
+    function() x
+  })
+
+  BC <- R6Class("BC",
+    inherit = AC,
+    public = list(
+      g = NULL
+    )
+  )
+
+  b <- BC$new()
+  b$f <- local_x1
+  b$g <- local_x2
+  expect_identical(b$f(), 1)
+  expect_identical(b$g(), 2)
+
+  b2 <- b$clone()
+  expect_identical(b2$f(), 1)
+  expect_identical(b2$g(), 2)
+
+  b3 <- b$clone()
+  expect_identical(b3$f(), 1)
+  expect_identical(b3$g(), 2)
+})

--- a/tests/testthat/test-clone.R
+++ b/tests/testthat/test-clone.R
@@ -407,98 +407,211 @@ test_that("Lock state", {
 
 
 test_that("Cloning inherited methods", {
+  # This set of tests makes sure that inherited methods refer to the correct
+  # self, private, and super. They also test multiple levels of inheritance.
+
+  # Base class
   C1 <- R6Class("C1",
     public = list(
       x = 1,
-      getx = function() self$x,
-      addx = function() self$x + 10
+      addx   = function() self$x + 100,
+      p_addx = function() private$addx_()
+    ),
+    private = list(
+      addx_  = function() self$x + 100
     ),
     active = list(
-      xa = function(val) {
-        if (missing(val)) self$x * 2
-        else self$x <- val / 2
-      }
+      a_addx = function(val) self$x + 100
     )
   )
 
-  C2 <- R6Class("C2",
+
+  # ==== Inherited methods ====
+  C2_inherit <- R6Class("C2_inherit",
     inherit = C1,
     public = list(
-      x = 2,
-      addx = function() super$addx() + 10
-    ),
-    active = list(
-      xa = function(val) {
-        if (missing(val)) self$x * 3
-        else self$x <- val / 3
-      }
+      x = 2
     )
   )
 
-  a <- C2$new()
+  a <- C2_inherit$new()
   b <- a$clone()
 
-  expect_identical(b$getx(), 2)
-  expect_identical(b$addx(), 22)
-  b$x <- 3
-  expect_identical(b$getx(), 3)
-  expect_identical(b$addx(), 23)
+  expect_identical(a$addx(),   102)
+  expect_identical(a$p_addx(), 102)
+  expect_identical(a$a_addx,   102)
+  expect_identical(a$addx(),   b$addx())
+  expect_identical(a$p_addx(), b$p_addx())
+  expect_identical(a$a_addx,   b$a_addx)
 
-  expect_identical(b$xa, 9)
-  b$xa <- 12
-  expect_identical(b$x, 4)
+  b$x <- 3
+  expect_identical(b$addx(),     103)
+  expect_identical(b$p_addx(),   103)
+  expect_identical(b$a_addx,     103)
 
   # Make sure a was unaffected
   expect_identical(a$x, 2)
 
 
-  # Same as previous, but with another copy and another level of inheritance
-  C3 <- R6Class("C3",
-    inherit = C2,
+  # ==== Overridden methods ====
+  C2_override <- R6Class("C2_override",
+    inherit = C1,
     public = list(
-      x = 3,
-      addx = function() super$addx() + 20
+      x = 2,
+      addx = function() super$addx() + self$x + 1000
+    ),
+    private = list(
+      addx_  = function() super$addx_() + self$x + 1000
     ),
     active = list(
-      xa = function(val) {
-        if (missing(val)) self$x * 4
-        else self$x <- val / 4
-      }
+      a_addx = function(val) super$a_addx + self$x + 1000
     )
   )
 
-  a <- C3$new()
+  a <- C2_override$new()
   b <- a$clone()
-  c <- b$clone()
-  b$x <- 4
-  c$x <- 5
-  expect_identical(a$getx(), 3)
-  expect_identical(a$addx(), 43)
-  expect_identical(b$getx(), 4)
-  expect_identical(b$addx(), 44)
-  expect_identical(c$getx(), 5)
-  expect_identical(c$addx(), 45)
 
-  expect_identical(c$xa, 20)
-  c$xa <- 24
-  expect_identical(c$x, 6)
+  expect_identical(a$addx(),   1104)
+  expect_identical(a$p_addx(), 1104)
+  expect_identical(a$a_addx,   1104)
+  expect_identical(a$addx(),   b$addx())
+  expect_identical(a$p_addx(), b$p_addx())
+  expect_identical(a$a_addx,   b$a_addx)
 
-  # Make sure a and b were unaffected
-  expect_identical(a$x, 3)
-  expect_identical(b$x, 4)
+  b$x <- 3
+  expect_identical(b$addx(),     1106)
+  expect_identical(b$p_addx(),   1106)
+  expect_identical(b$a_addx,     1106)
+
+  # Make sure a was unaffected
+  expect_identical(a$x, 2)
 
 
-  # Three levels; don't override active binding
-  C3na <- R6Class("C3na",
-    inherit = C2,
-    public = list(x = 3)
+  # ===========================================================================
+  # Sub-sub-classes:
+  # Need to check sequences of:
+  # inherit-inherit, inherit-override, override-inherit, and override-override
+
+  # ==== Inherit-inherit methods ====
+  C3_inherit_inherit <- R6Class("C3_inherit_inherit",
+    inherit = C2_inherit,
+    public = list(
+      x = 3
+    )
   )
-  a <- C3na$new()
+
+  a <- C3_inherit_inherit$new()
   b <- a$clone()
+
+  expect_identical(a$addx(),   103)
+  expect_identical(a$p_addx(), 103)
+  expect_identical(a$a_addx,   103)
+  expect_identical(a$addx(),   b$addx())
+  expect_identical(a$p_addx(), b$p_addx())
+  expect_identical(a$a_addx,   b$a_addx)
+
   b$x <- 4
-  expect_identical(b$xa, 12)
-  b$xa <- 15
-  expect_identical(b$x, 5)
+  expect_identical(b$addx(),   104)
+  expect_identical(b$p_addx(), 104)
+  expect_identical(b$a_addx,   104)
+
+  # Make sure a was unaffected
+  expect_identical(a$x, 3)
+
+
+  # ==== Inherit-override methods ====
+  C3_inherit_override <- R6Class("C3_inherit_override",
+    inherit = C2_inherit,
+    public = list(
+      x = 3,
+      addx = function() super$addx() + self$x + 10000
+    ),
+    private = list(
+      addx_  = function() super$addx_() + self$x + 10000
+    ),
+    active = list(
+      a_addx = function(val) super$a_addx + self$x + 10000
+    )
+  )
+
+  a <- C3_inherit_override$new()
+  b <- a$clone()
+
+  expect_identical(a$addx(),   10106)
+  expect_identical(a$p_addx(), 10106)
+  expect_identical(a$a_addx,   10106)
+  expect_identical(a$addx(),   b$addx())
+  expect_identical(a$p_addx(), b$p_addx())
+  expect_identical(a$a_addx,   b$a_addx)
+
+  b$x <- 4
+  expect_identical(b$addx(),   10108)
+  expect_identical(b$p_addx(), 10108)
+  expect_identical(b$a_addx,   10108)
+
+  # Make sure a was unaffected
+  expect_identical(a$x, 3)
+
+
+  # ==== Override-override methods ====
+  C3_override_override <- R6Class("C3_override_override",
+    inherit = C2_override,
+    public = list(
+      x = 3,
+      addx = function() super$addx() + self$x + 10000
+    ),
+    private = list(
+      addx_  = function() super$addx_() + self$x + 10000
+    ),
+    active = list(
+      a_addx = function(val) super$a_addx + self$x + 10000
+    )
+  )
+
+  a <- C3_override_override$new()
+  b <- a$clone()
+
+  expect_identical(a$addx(),   11109)
+  expect_identical(a$p_addx(), 11109)
+  expect_identical(a$a_addx,   11109)
+  expect_identical(a$addx(),   b$addx())
+  expect_identical(a$p_addx(), b$p_addx())
+  expect_identical(a$a_addx,   b$a_addx)
+
+  b$x <- 4
+  expect_identical(b$addx(),   11112)
+  expect_identical(b$p_addx(), 11112)
+  expect_identical(b$a_addx,   11112)
+
+  # Make sure a was unaffected
+  expect_identical(a$x, 3)
+
+
+  # ==== Override-inherit methods ====
+  C3_override_inherit <- R6Class("C3_override_inherit",
+    inherit = C2_override,
+    public = list(
+      x = 3
+    )
+  )
+
+  a <- C3_override_inherit$new()
+  b <- a$clone()
+
+  expect_identical(a$addx(),   1106)
+  expect_identical(a$p_addx(), 1106)
+  expect_identical(a$a_addx,   1106)
+  expect_identical(a$addx(),   b$addx())
+  expect_identical(a$p_addx(), b$p_addx())
+  expect_identical(a$a_addx,   b$a_addx)
+
+  b$x <- 4
+  expect_identical(b$addx(),   1108)
+  expect_identical(b$p_addx(), 1108)
+  expect_identical(b$a_addx,   1108)
+
+  # Make sure a was unaffected
+  expect_identical(a$x, 3)
 })
 
 


### PR DESCRIPTION
Fixes #155, fixes #94, fixes #133. The latter two issues are that when cloning an object with a function that is not a method, the new object would turn it into a method, and alter the environment.

This now works:

```R
A <- R6Class("A",
  public = list(
    f = NULL
  )
)

a <- A$new()
self <- 1
a$f <- function() self
expect_identical(a$f(), 1)

a2 <- a$clone()
expect_identical(a2$f(), 1)
```

@thomasp85, @cpsievert, I believe you guys asked about this in an issue in another repo, but I can't remember where it was.