### PR TITLE
Added tests on as.list, is.R6, and is.R6Class

### DIFF
--- a/tests/testthat/test-aslist.R
+++ b/tests/testthat/test-aslist.R
@@ -1,0 +1,10 @@
+context("aslist")
+
+test_that("as.list() works as expected", {
+  AC <- R6Class("AC", public = list(x = 1))
+  ac <- AC$new()
+  lst <- as.list(ac)
+  expect_true(methods::is(lst, "list"))
+  expect_named(lst, c(".__enclos_env__", "x", "clone"))
+  expect_true(lst[["x"]] == 1)
+})

--- a/tests/testthat/test-is.R
+++ b/tests/testthat/test-is.R
@@ -1,0 +1,32 @@
+context("is")
+
+test_that("is.R6 works as expected on R6 and R6Class objects", {
+  AC <- R6Class("AC", public = list(x = 1))
+  ac <- AC$new()
+
+  expect_false(is.R6(AC))
+  expect_true(is.R6(ac))
+})
+
+test_that("is.R6Class works as expected on R6 and R6Class objects", {
+  AC <- R6Class("AC", public = list(x = 1))
+  ac <- AC$new()
+
+  expect_true(is.R6Class(AC))
+  expect_false(is.R6Class(ac))
+})
+
+test_that("is.R6 and is.R6Class work as expected on non-R6 objects", {
+  test_objects <- list(
+    "int" = 1L,
+    "int_vec" = rep(9L, 10),
+    "char" = "hello",
+    "charvec" = LETTERS,
+    "data.frame" = data.frame(x = rnorm(10), y = rnorm(10)),
+    "matrix" = matrix(runif(10), 2, 5)
+  )
+  for (obj in test_objects){
+    expect_false(is.R6(obj))
+    expect_false(is.R6Class(obj))
+  }
+})


### PR DESCRIPTION
Thank you for this awesome project! I use `R6` every day and it's made me a much more productive R programmer.

To thank you, I thought I'd come in and look for easy tests to write that could cover some currently-uncovered lines in the codebase. I hope you'll consider this PR to add minimal unit tests on `as.list()`, `is.R6()`, and `is.R6Class()`.

I found these uncovered lines with this nifty thing my friends and I user in our projects:

```
Rscript -e "coverage <- covr::package_coverage('.'); print(coverage); covr::report(coverage, './coverage.html')"
open coverage.html
```