### PR TITLE
Error message about duplicated entries shows duplicates

### DIFF
--- a/R/r6_class.R
+++ b/R/r6_class.R
@@ -476,8 +476,13 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
     stop("All elements of public, private, and active must be named.")
 
   allnames <- c(names(public), names(private), names(active))
-  if (any(duplicated(allnames)))
-    stop("All items in public, private, and active must have unique names.")
+  if (anyDuplicated(allnames)) {
+    stop(
+      "All items in public, private, and active must have unique names. ",
+      "Non unique names: ",
+      paste(allnames[duplicated(allnames)], collapse = ", " )
+    )
+  }
 
   if ("clone" %in% allnames)
     stop("Cannot add a member with reserved name 'clone'.")


### PR DESCRIPTION
Would be definitively helpful for me sometimes.
I didn't change the first part of the error message because I was afraid people might regexp-test against it (although unlikely).
If you want any changes, let me know.