### PR TITLE
new() gets formals from initialize()

### DIFF
--- a/R/generator_funs.R
+++ b/R/generator_funs.R
@@ -69,6 +69,10 @@ generator_funs$set <- function(which = NULL, name = NULL, value, overwrite = FAL
 
   self[[group]][[name]] <- value
 
+  if (name == "initialize" && is.function(value)) {
+    self$new <- inject_new_args(self$new, formals(value))
+  }
+
   invisible()
 }
 

--- a/R/new.R
+++ b/R/new.R
@@ -1,7 +1,24 @@
+# This is the $new() method that is user-facing. It's simply a wrapper that
+# calls .new_dots(). It exists because it will be modified to have the formals
+# from the user-defined initialize method, to support auto-completion.
+generator_funs$new <- function() {
+  .new_impl()
+}
+
+# Modifies the $new method so that it gets the $initialize method's formals.
+inject_new_args <- function(fn, args) {
+  formals(fn) <- args
+  # Change the body of generator_funs$new here. If the args are, for example,
+  # `a, b=1, ...`, then replace `.new_dots()` with `.new_dots(a, b, ...)`.
+  body(fn)[[2]][seq_along(args) + 1] <- lapply(names(args), as.name)
+
+  fn
+}
+
 # This is the $new function for a R6ClassGenerator. This copy of it won't run
 # properly; it needs to be copied, and its parent environment set to the
 # generator object environment.
-generator_funs$.new_dots <- function(...) {
+generator_funs$.new_impl <- function(...) {
   # Get superclass object -------------------------------------------
   inherit <- get_inherit()
 

--- a/R/new.R
+++ b/R/new.R
@@ -1,7 +1,7 @@
 # This is the $new function for a R6ClassGenerator. This copy of it won't run
 # properly; it needs to be copied, and its parent environment set to the
 # generator object environment.
-generator_funs$new <- function(...) {
+generator_funs$new_dots <- function(...) {
   # Get superclass object -------------------------------------------
   inherit <- get_inherit()
 

--- a/R/new.R
+++ b/R/new.R
@@ -1,7 +1,7 @@
 # This is the $new function for a R6ClassGenerator. This copy of it won't run
 # properly; it needs to be copied, and its parent environment set to the
 # generator object environment.
-generator_funs$new_dots <- function(...) {
+generator_funs$.new_dots <- function(...) {
   # Get superclass object -------------------------------------------
   inherit <- get_inherit()
 

--- a/R/r6_class.R
+++ b/R/r6_class.R
@@ -510,7 +510,7 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
 
   # Add a "new" function that wraps ".new_dots"
   generator_funs <- generator_funs
-  generator_funs$new <- wrap_dots_fun(".new_dots", public$initialize, generator)
+  generator_funs$new <- wrap_dots_fun(generator_funs$.new_dots, ".new_dots", public$initialize)
 
   # Copy the generator functions into the generator env.
   list2env2(generator_funs, generator)
@@ -545,9 +545,9 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
   generator
 })
 
-wrap_dots_fun <- function(dots_fun_name, arglist_fun, envir) {
-  if (is.null(arglist_fun)) {
-    arglist_fun <- function(...) NULL
+wrap_dots_fun <- function(dots_fun, dots_fun_name, arglist_fun) {
+  if (is.null(arglist_fun) || identical(formals(arglist_fun), as.pairlist(alist(... = )))) {
+    return(dots_fun)
   }
 
   my_formals <- formals(arglist_fun)
@@ -561,7 +561,7 @@ wrap_dots_fun <- function(dots_fun_name, arglist_fun, envir) {
     }
   ))
 
-  environment(new_fun) <- envir
+  environment(new_fun) <- environment(dots_fun)
   formals(new_fun) <- my_formals
 
   new_fun

--- a/R/r6_class.R
+++ b/R/r6_class.R
@@ -548,7 +548,7 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
 
 wrap_dots_fun <- function(dots_fun, arglist_fun) {
   if (is.null(arglist_fun)) {
-    return(dots_fun)
+    arglist_fun <- function() NULL
   }
 
   my_formals <- formals(arglist_fun)

--- a/R/r6_class.R
+++ b/R/r6_class.R
@@ -508,10 +508,9 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
   # Set the generator functions to eval in the generator environment
   generator_funs <- assign_func_envs(generator_funs, generator)
 
-  # Add a "new" function that wraps "new_dots"
+  # Add a "new" function that wraps ".new_dots"
   generator_funs <- generator_funs
-  generator_funs$new <- wrap_dots_fun(generator_funs$new_dots, public$initialize)
-  generator_funs$new_dots <- NULL
+  generator_funs$new <- wrap_dots_fun(".new_dots", public$initialize, generator)
 
   # Copy the generator functions into the generator env.
   list2env2(generator_funs, generator)
@@ -546,7 +545,7 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
   generator
 })
 
-wrap_dots_fun <- function(dots_fun, arglist_fun) {
+wrap_dots_fun <- function(dots_fun_name, arglist_fun, envir) {
   if (is.null(arglist_fun)) {
     arglist_fun <- function(...) NULL
   }
@@ -554,16 +553,15 @@ wrap_dots_fun <- function(dots_fun, arglist_fun) {
   my_formals <- formals(arglist_fun)
   my_formals_names <- lapply(names(my_formals), as.name)
   names(my_formals_names) <- names(my_formals)
-  dots_fun_call <- as.call(c(quote(dots_fun), my_formals_names))
+  dots_fun_call <- as.call(c(as.name(dots_fun_name), my_formals_names))
 
   new_fun <- eval(bquote(
     function() {
-      dots_fun <- .(dots_fun)
       .(dots_fun_call)
     }
   ))
 
-  environment(new_fun) <- environment(dots_fun)
+  environment(new_fun) <- envir
   formals(new_fun) <- my_formals
 
   new_fun

--- a/R/r6_class.R
+++ b/R/r6_class.R
@@ -548,7 +548,7 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
 
 wrap_dots_fun <- function(dots_fun, arglist_fun) {
   if (is.null(arglist_fun)) {
-    arglist_fun <- function() NULL
+    arglist_fun <- function(...) NULL
   }
 
   my_formals <- formals(arglist_fun)

--- a/tests/testthat/test-initialize.R
+++ b/tests/testthat/test-initialize.R
@@ -24,3 +24,9 @@ test_that("initializer with dots", {
   Initializer <- R6Class("Initializer", public = list(initialize = function(a = "", ..., b) NULL))
   expect_identical(formals(Initializer$new), as.pairlist(alist(a = "", ... = , b = )))
 })
+
+test_that("inherited initializer", {
+  A <- R6Class("A", public = list(initialize = function(a = "", ..., b) NULL))
+  B <- R6Class("B", inherit = A)
+  expect_identical(formals(B$new), formals(A$new))
+})

--- a/tests/testthat/test-initialize.R
+++ b/tests/testthat/test-initialize.R
@@ -1,35 +1,72 @@
 context("initialize")
 
-test_that("no initializer", {
+test_that("new() args with no initialize()", {
   NoInitializer <- R6Class("NoInitializer")
-
-  # Absence of initializer means we might use an inherited initializer,
-  # but we don't know its interface at the time the class is created (#12).
-  expect_identical(formals(NoInitializer$new), as.pairlist(alist(... = )))
+  expect_identical(formals(NoInitializer$new), NULL)
 })
 
-test_that("empty initializer", {
+test_that("new() args with empty initialize()", {
   EmptyInitializer <- R6Class("EmptyInitializer", public = list(initialize = function() NULL))
   expect_null(formals(EmptyInitializer$new))
 })
 
-test_that("initializer with args", {
+test_that("new() args with initialize() with args", {
   Initializer <- R6Class("Initializer", public = list(initialize = function(a) NULL))
   expect_identical(formals(Initializer$new), as.pairlist(alist(a = )))
 })
 
-test_that("initializer with args and defaults", {
+test_that("new() args with initialize() with args and defaults", {
   Initializer <- R6Class("Initializer", public = list(initialize = function(a = "", b) NULL))
   expect_identical(formals(Initializer$new), as.pairlist(alist(a = "", b = )))
 })
 
-test_that("initializer with dots", {
+test_that("new() args with initialize() with dots", {
   Initializer <- R6Class("Initializer", public = list(initialize = function(a = "", ..., b) NULL))
   expect_identical(formals(Initializer$new), as.pairlist(alist(a = "", ... = , b = )))
 })
 
-test_that("inherited initializer", {
+test_that("new() args with inherited initialize() with args", {
   A <- R6Class("A", public = list(initialize = function(a = "", ..., b) NULL))
   B <- R6Class("B", inherit = A)
   expect_identical(formals(B$new), as.pairlist(alist(... = )))
+})
+
+test_that("new() args with inherited class without initialize()", {
+  # For a subclass without its own initialize() method, the $new() method must
+  # take `...` because the superclass might have an initializer -- the
+  # inheritance is resolved when $new() is called, and not before (see #12 for
+  # reasons why), so the $new() method can't know whether the superclass has an
+  # initializer, or what its parameters are.
+  A <- R6Class("A")
+  B <- R6Class("B", inherit = A)
+  expect_identical(formals(B$new), as.pairlist(alist(... = )))
+})
+
+
+test_that("Missingness is passed along to initialize()", {
+  Missing <- R6Class("Missing",
+    public = list(
+      initialize = function(a, b = 1) {
+        self$missing_a <- missing(a)
+        self$missing_b <- missing(b)
+      },
+      missing_a = NULL,
+      missing_b = NULL
+    )
+  )
+
+  x <- Missing$new()
+  expect_true(x$missing_a)
+  # It would be nice if this were TRUE, but currently I don't see a
+  # straightforward way to make that work, and it's extremely rare that a
+  # parameter would have a default value AND a check for missing.
+  expect_false(x$missing_b)
+
+
+  MissingSubclass <- R6Class("MissingSubclass", inherit = Missing)
+  x <- MissingSubclass$new()
+  expect_true(x$missing_a)
+  # Missingness is correctly passed along in this case, because
+  # MissingSubclass$new() takes `...`.
+  expect_true(x$missing_b)
 })

--- a/tests/testthat/test-initialize.R
+++ b/tests/testthat/test-initialize.R
@@ -2,7 +2,10 @@ context("initialize")
 
 test_that("no initializer", {
   NoInitializer <- R6Class("NoInitializer")
-  expect_null(formals(NoInitializer$new))
+
+  # Absence of initializer means we might use an inherited initializer,
+  # but we don't know its interface at the time the class is created (#12).
+  expect_identical(formals(NoInitializer$new), as.pairlist(alist(... = )))
 })
 
 test_that("empty initializer", {
@@ -28,5 +31,5 @@ test_that("initializer with dots", {
 test_that("inherited initializer", {
   A <- R6Class("A", public = list(initialize = function(a = "", ..., b) NULL))
   B <- R6Class("B", inherit = A)
-  expect_identical(formals(B$new), formals(A$new))
+  expect_identical(formals(B$new), as.pairlist(alist(... = )))
 })

--- a/tests/testthat/test-initialize.R
+++ b/tests/testthat/test-initialize.R
@@ -1,0 +1,26 @@
+context("initialize")
+
+test_that("no initializer", {
+  NoInitializer <- R6Class("NoInitializer")
+  expect_null(formals(NoInitializer$new))
+})
+
+test_that("empty initializer", {
+  EmptyInitializer <- R6Class("EmptyInitializer", public = list(initialize = function() NULL))
+  expect_null(formals(EmptyInitializer$new))
+})
+
+test_that("initializer with args", {
+  Initializer <- R6Class("Initializer", public = list(initialize = function(a) NULL))
+  expect_identical(formals(Initializer$new), as.pairlist(alist(a = )))
+})
+
+test_that("initializer with args and defaults", {
+  Initializer <- R6Class("Initializer", public = list(initialize = function(a = "", b) NULL))
+  expect_identical(formals(Initializer$new), as.pairlist(alist(a = "", b = )))
+})
+
+test_that("initializer with dots", {
+  Initializer <- R6Class("Initializer", public = list(initialize = function(a = "", ..., b) NULL))
+  expect_identical(formals(Initializer$new), as.pairlist(alist(a = "", ... = , b = )))
+})


### PR DESCRIPTION
Closes #104. This is a modification of #103, but with code that is a bit easier for me to understand.

Now `new()` doesn't just take `...`; it gets its arguments from the `initialize()` method.

One exception is when a subclass doesn't define its own `initialize` method. In that case, `new()` just takes `...` and passes them along to the superclass's `initialize()`. This is because the inheritance is resolved when `new()` is _called_, not when the class is defined, so the content of the superclass's `initialize()` method cannot be known before `new()` is called.
