### PR TITLE
Don't rely on buggy as.list.environment behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: r
 r:
+  - 3.2
   - oldrel
   - release
   - devel
+    env:
+    - _R_ENV2LIST_BUGFIX_=true
+
 sudo: false
 cache: packages
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ R6 2.4.0.9000
 
 * Closed [#104](https://github.com/r-lib/R6/issues/104)The `new()` method for class generators now inherits arguments from the `initialize()` method. This means that tab-completion can be used with `new()`. ([#191](https://github.com/r-lib/R6/pull/191))
 
+* Cloning active bindings previously relied on buggy behavior in `as.list.environment()`, which would return the active binding's function definition rather than the value from invoking the function. In R 4.0, the behavior will chang so that it returns the value. R6 now no longer relies on this buggy behavior. ([#192](https://github.com/r-lib/R6/pull/192))
+
 R6 2.4.0
 ========
 

--- a/R/r6_class.R
+++ b/R/r6_class.R
@@ -536,6 +536,7 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
   generator$classname    <- classname
   generator$active       <- active
   generator$portable     <- portable
+  generator$cloneable    <- cloneable
   generator$parent_env   <- parent_env
   generator$lock_objects <- lock_objects
   generator$class        <- class


### PR DESCRIPTION
In R-devel, with the environment var `_R_ENV2LIST_BUGFIX_=true`, the `as.list.environment()` function no longer gives the function associated with an active binding; it calls the function and gives the returned value instead. This will become the default (probably) in R 4.0.

This buggy behavior was used when cloning an R6 object with active bindings. This PR fixes the issue by storing the functions for active bindings separately, if the object is cloneable.
