### PR TITLE
Fix env for cloned portable classes with inheritance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ R6 2.4.1.9001
 
 * Resolved #195: Slightly clearer message when there is an error in the `initialize()` method.
 
-* Fixed #214: When a non-portable object inheritance was cloned, methods that were inherited (and not overridden) had the wrong environment. (#215)
+* Fixed #214: When a non-portable object inheritance was cloned, methods that were inherited (and not overridden) had the wrong environment. (#215, #217)
 
 * Printing R6 objects, no longer includes `.__active__`.
 

--- a/R/clone.R
+++ b/R/clone.R
@@ -158,7 +158,7 @@ generator_funs$clone_method <- function(deep = FALSE) {
 
 
   # This creates a slice other than the first one.
-  make_new_slice <- function(old_slice, self, private, enclosing_parent, portable) {
+  make_new_slice <- function(old_slice, self, private, enclosing_parent) {
     enclosing <- new.env(enclosing_parent, hash = FALSE)
     binding   <- new.env(emptyenv(), hash = FALSE)
 
@@ -187,12 +187,17 @@ generator_funs$clone_method <- function(deep = FALSE) {
   # Mirror the super environments from the old object
   if (length(old) > 1) {
     for (i in seq.int(2, length(old))) {
+      if (portable) {
+        enclosing_parent <- parent.env(old[[i]]$enclosing)
+      } else {
+        enclosing_parent <- new_1_enclosing
+      }
+
       new[[i]] <- make_new_slice(
         old[[i]],
         new_1_binding,
         new_1_private,
-        new_1_enclosing,
-        portable
+        enclosing_parent
       )
     }
 


### PR DESCRIPTION
When a portable object with an inherited method is cloned, the cloned object's method did not have the correct environment. This was introduced by #215, and it was the cause of https://github.com/mlr-org/mlr3/issues/568.

In this example, `b2$getx()` should return 1, but it returns 2:

```R
library(R6)
A <- local({
  x <- 1
  R6Class("A",
    public = list(
      getx = function() x
    )
  )
})

B <- local({
  x <- 2
  R6Class("B",
    inherit = A,
    public = list(
      getx_super = function() super$getx()
    )
  )
})


b <- B$new()
# Inherited method
b$getx()
#> [1] 1
# Method which calls super
b$getx_super()
#> [1] 1

b2 <- b$clone()
b2$getx()
#> [1] 2
b2$getx_super()
#> [1] 2
```

This PR fixes the issue.