### PR TITLE
use `{lobstr}` instead of `{pryr}`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,9 +11,9 @@ Description: Creates classes with reference semantics, similar to R's built-in
 Depends:
     R (>= 3.0)
 Suggests:
-    testthat,
-    pryr
+    lobstr,
+    testthat
 License: MIT + file LICENSE
 URL: https://r6.r-lib.org, https://github.com/r-lib/R6/
 BugReports: https://github.com/r-lib/R6/issues
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/tests/manual/encapsulation.R
+++ b/tests/manual/encapsulation.R
@@ -1,4 +1,4 @@
-library(pryr)
+library(lobstr)
 library(testthat)
 library(inline)
 

--- a/tests/testthat/test-portable-inheritance.R
+++ b/tests/testthat/test-portable-inheritance.R
@@ -392,8 +392,8 @@ test_that("Inheritance is dynamic", {
 
   # BC doesn't contain AC, and it has less stuff in it, so it should be smaller
   # than AC.
-  if (requireNamespace("pryr", quietly = TRUE)) {
-    expect_true(pryr::object_size(BC) < pryr::object_size(AC))
+  if (requireNamespace("lobstr", quietly = TRUE)) {
+    expect_true(lobstr::obj_size(BC) < lobstr::obj_size(AC))
   }
 })
 

--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -3,7 +3,7 @@ title: "Introduction"
 ---
 
 ```{r echo = FALSE}
-library(pryr)
+library(lobstr)
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
 ```
 
@@ -382,21 +382,20 @@ NonCloneable <- R6Class("NonCloneable", cloneable = FALSE)
 c1 <- Cloneable$new()
 c2 <- Cloneable$new()
 # Bytes for each new cloneable object
-cloneable_delta <- object_size(c1, c2) - object_size(c2)
+cloneable_delta <- obj_size(c1, c2) - obj_size(c2)
 
 nc1 <- NonCloneable$new()
 nc2 <- NonCloneable$new()
 # Bytes for each new noncloneable object
-noncloneable_delta <- object_size(nc1, nc2) - object_size(nc2)
+noncloneable_delta <- obj_size(nc1, nc2) - obj_size(nc2)
 
 # Number of bytes used by each copy of clone method
 additional_clone_method_bytes <- cloneable_delta - noncloneable_delta
-additional_clone_method_bytes_str <- capture.output(print(additional_clone_method_bytes))
+additional_clone_method_bytes
 
 # Number of bytes used by first copy of a clone method
-first_clone_method_bytes <- object_size(c1) - object_size(nc1)
-# Need some trickery to get the nice output from pryr::print.bytes
-first_clone_method_bytes_str <- capture.output(print(first_clone_method_bytes))
+first_clone_method_bytes <- obj_size(c1) - obj_size(nc1)
+first_clone_method_bytes
 ```
 
 If you don't want a `clone` method to be added, you can use `cloneable=FALSE` when creating the class. If any loaded R6 object has a `clone` method, that function uses `r first_clone_method_bytes_str`, but for each additional object, the `clone` method costs a trivial amount of space (`r additional_clone_method_bytes` bytes).

--- a/vignettes/Performance.Rmd
+++ b/vignettes/Performance.Rmd
@@ -47,7 +47,7 @@ First we'll load some packages which will be used below:
 ```{r eval = FALSE}
 library(microbenchmark)
 options(microbenchmark.unit = "us")
-library(pryr)  # For object_size function
+library(lobstr)  # For obj_size function
 library(R6)
 ```
 
@@ -59,7 +59,7 @@ if (requireNamespace("microbenchmark", quietly = TRUE)) {
   library(microbenchmark)
 }
 options(microbenchmark.unit = "us")
-library(pryr)  # For object_size function
+library(lobstr)  # For obj_size function
 library(R6)
 ```
 
@@ -310,7 +310,7 @@ For all the timings using `microbenchmark()`, the results are reported in micros
 obj_size <- function(expr, .env = parent.frame()) {
   size_n <- function(n = 1) {
     objs <- lapply(1:n, function(x) eval(expr, .env))
-    as.numeric(do.call(object_size, objs))
+    as.numeric(do.call(obj_size, objs))
   }
 
   data.frame(one = size_n(1), incremental = size_n(2) - size_n(1))
@@ -402,7 +402,7 @@ RC2 <- setRefClass("RC2",
 )
 
 # Calcualte the size of a new RC2 object, over and above an RC object
-as.numeric(object_size(RC$new(), RC2$new()) - object_size(RC$new()))
+as.numeric(obj_size(RC$new(), RC2$new()) - obj_size(RC$new()))
 ```
 
 ## Object instantiation speed
@@ -748,7 +748,7 @@ Appendix
 obj_size <- function(expr, .env = parent.frame()) {
   size_n <- function(n = 1) {
     objs <- lapply(1:n, function(x) eval(expr, .env))
-    as.numeric(do.call(object_size, objs))
+    as.numeric(do.call(obj_size, objs))
   }
 
   data.frame(one = size_n(1), incremental = size_n(2) - size_n(1))


### PR DESCRIPTION
- no tricks needed for printing object sizes in Intro vignette