### PR TITLE
Update introductory vignette

### DIFF
--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -267,7 +267,7 @@ myMallard$quack()
 
 ### Fields containing reference objects
 
-If your R6 class contains any fields that also have reference semantics (e.g., other R6 objects, environments), those fields should be populated in the `initialize` method. If the field is set to the reference object directly in the class definition, that object will be shared across all instances of that R6 class. 
+If your R6 class contains any fields that also have reference semantics (e.g., other R6 objects, environments), those fields should be populated in the `$initialize()` method. If the field is set to the reference object directly in the class definition, that object will be shared across all instances of that R6 class. 
 
 Here's an example:
 
@@ -420,7 +420,7 @@ If you don't want a `clone` method to be added, you can use `cloneable=FALSE` wh
 
 If there are any fields that are objects with reference semantics (environments, R6 objects, reference class objects), the copy will get a reference to the same object. This is sometimes desirable, but often it is not.
 
-For example, we'll create an object `c1` which contains another R6 object, `s`, and then clone it. Because both the original and the clone object's `s` field refers to the same object, and modifying it from one results in a change that is reflected in the other.
+For example, we'll create an object `c1` which contains another R6 object, `s`, and then clone it. Because both the original and the clone object's `s` field refers to the same object, modifying it from one results in a change that is reflected in the other.
 
 ```{r}
 Simple <- R6Class("Simple", public = list(x = 1))
@@ -580,7 +580,7 @@ obj <- A$new()
 rm(obj); gc()
 ```
 
-**NOTE:** In R6 version 2.3.0 (released 2018-10-04) and below, the `finalize` method could only be public. As of version 2.4.0, it can be public or private. Private is preferable because there's no reason a finalizer needs to be publicly accessible. If you use a private finalizer in an R package, you should set your R6 version dependency to `R6 (>= 2.4.0)`. In 2.6.0, R6 prints a message if a finalizer is public. In a future version, it will emit warnings, and finally, it will no longer support public finalizers.
+**NOTE:** In R6 version 2.3.0 (released 2018-10-04) and below, the `$finalize()` method could only be public. As of version 2.4.0, it can be public or private. Private is preferable because there's no reason a finalizer needs to be publicly accessible. If you use a private finalizer in an R package, you should set your R6 version dependency to `R6 (>= 2.4.0)`. In 2.6.0, R6 prints a message if a finalizer is public. In a future version, it will emit warnings, and finally, it will no longer support public finalizers.
 
 Finalizers are implemented using the `reg.finalizer()` function, and they set `onexit=TRUE`, so that the finalizer will also be called when R exits. This is useful in some cases, like database connections.
 

--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -120,9 +120,11 @@ q$remove()
 
 However, private members can't be accessed directly:
 
-```{r, error=TRUE}
+```{r eval = FALSE}
 q$queue
+#> NULL
 q$length()
+#> Error: attempt to apply non-function
 ```
 
 A useful design pattern is for methods to return `self` (invisibly) when possible, because it makes them chainable. For example, the `add()` method returns `self` so you can chain them together:
@@ -178,12 +180,13 @@ n$x
 
 If the function takes no arguments, it's not possible to use it with `<-`:
 
-```{r error=TRUE}
-set.seed(123) # for reproducibility
-
+```{r eval=FALSE}
 n$rand
+#> [1] 0.2648
 n$rand
+#> [1] 2.171
 n$rand <- 3
+#> Error: unused argument (quote(3))
 ```
 
 Implementation note: Active bindings are bound in the public environment. The enclosing environment for these functions is also the public environment.

--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -520,7 +520,7 @@ In the example `deep_clone` method above, we checked the name of each field to d
 
 If a given R6 class is a subclass, its cloning behavior will be contingent on the cloning behavior of its superclass. Specifically, there are two possibilities:
 
-1. If the superclass has `cloneable = TRUE`, no matter what subclass has set for `cloneable`, cloning will always work.
+1. If the superclass has `cloneable=TRUE`, no matter what subclass has set for `cloneable`, cloning will always work.
 
 For example, let's create R6 class called `Creature` with `cloneable` set to `TRUE`.
 

--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -518,17 +518,16 @@ In the example `deep_clone` method above, we checked the name of each field to d
 
 #### Cloning inheritance
 
-If a given R6 class is a subclass, the specified cloning behavior in this subclass will be overridden by that in the superclass.
+If a given R6 class is a subclass, its cloning behavior will be contingent on the cloning behavior of its superclass. Specifically, there are two possibilities:
 
-For example, let's create R6 class called `Creature`. Instances of this class can be cloned by setting `cloneable=TRUE`.
+1. If the superclass has `cloneable = TRUE`, no matter what subclass has set for `cloneable`, cloning will always work.
+
+For example, let's create R6 class called `Creature` with `cloneable` set to `TRUE`.
 
 ```{r}
 Creature <- R6Class("Creature",
   cloneable = TRUE
 )
-
-# cloning for class objects possible
-Creature$new()$clone()
 ```
 
 If we now create R6 subclass `Human` that inherits from `Creature` class, even if we set `cloneable=FALSE`, cloning instances of this subclass will still be possible because the superclass allows cloning:
@@ -541,6 +540,37 @@ Human <- R6Class("Human",
 
 # cloning still possible even when `cloneable` is set to `FALSE`
 Human$new()$clone()
+```
+
+2. If the superclass has `cloneable = FALSE`, the `cloneable` property of the subclass will be respected.
+
+Let's use the same example as before but set `cloneable` to `FALSE` this time.
+
+```{r}
+Creature <- R6Class("Creature",
+  cloneable = FALSE
+)
+```
+
+Now, the sublass will respect `cloneable` property in the subclass:
+
+```{r}
+Human <- R6Class("Human",
+  inherit = Creature,
+  cloneable = TRUE
+)
+
+Human$new()$clone()
+```
+
+```{r, eval=FALSE}
+Human <- R6Class("Human",
+  inherit = Creature,
+  cloneable = FALSE
+)
+
+Human$new()$clone()
+#> Error: attempt to apply non-function
 ```
 
 ### Printing R6 objects to the screen

--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -179,6 +179,8 @@ n$x
 If the function takes no arguments, it's not possible to use it with `<-`:
 
 ```{r error=TRUE}
+set.seed(123) # for reproducibility
+
 n$rand
 n$rand
 n$rand <- 3

--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -11,7 +11,7 @@ The R6 package provides an implementation of encapsulated object-oriented progra
 
 ## R6 classes
 
-R6 classes are similar to R's reference classes but are smaller in size, and avoid some issues that come along with using S4 (R's reference classes are based on S4). For more information about speed and memory footprint, see `vignette("Performance")`.
+R6 classes are similar to R's reference classes, but are lighter weight, and avoid some issues that come along with using S4 (R's reference classes are based on S4). For more information about speed and memory footprint, see `vignette("Performance")`.
 
 Unlike many objects in R, instances (objects) of R6 classes have reference semantics. R6 classes also support:
 
@@ -423,9 +423,9 @@ If you don't want a `clone` method to be added, you can use `cloneable=FALSE` wh
 
 #### Deep cloning
 
-If there are any fields that are objects with reference semantics (environments, R6 objects, reference class objects), the copy will get a reference to the same object. This is sometimes desirable, but often it is not.
+If there are any fields which are objects with reference semantics (environments, R6 objects, reference class objects), the copy will get a reference to the same object. This is sometimes desirable, but often it is not.
 
-For example, we'll create an object `c1` which contains another R6 object, `s`, and then clone it. Because both the original and the clone object's `s` field refers to the same object, modifying it from one results in a change that is reflected in the other.
+For example, we'll create an object `c1` which contains another R6 object, `s`, and then clone it. Because the original's and the clone's `s` fields both refer to the same object, modifying it from one results in a change that is reflected in the other.
 
 ```{r}
 Simple <- R6Class("Simple", public = list(x = 1))
@@ -447,7 +447,7 @@ c1$s$x <- 2
 c2$s$x
 ```
 
-To make sure that the clone receives a *copy* of `s`, we can use the `deep=TRUE` option:
+To make it so the clone receives a *copy* of `s`, we can use the `deep=TRUE` option:
 
 ```{r}
 c3 <- c1$clone(deep = TRUE)
@@ -459,7 +459,7 @@ c1$s$x <- 3
 c3$s$x
 ```
 
-The default behavior of `$clone(deep=TRUE)` is to copy fields that are R6 objects, but not to copy fields that are environments, reference class objects, or other data structures which contain other reference-type objects (for example, a list with an R6 object).
+The default behavior of `$clone(deep=TRUE)` is to copy fields which are R6 objects, but not copy fields which are environments, reference class objects, or other data structures which contain other reference-type objects (for example, a list with an R6 object).
 
 If your R6 object contains these types of objects and you want to make a deep clone of them, you must provide your own function for deep cloning, in a private method named `deep_clone`. Below is an example of an R6 object with two fields, `a` and `b`, both of which which are environments, and both of which contain a value `x`. It also has a field `v` which is a regular (non-reference) value, and a private `deep_clone` method.
 

--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -11,7 +11,7 @@ The R6 package provides an implementation of encapsulated object-oriented progra
 
 ## R6 classes
 
-R6 classes are similar to R's reference classes, but are lighter weight, and avoid some issues that come along with using S4 (R's reference classes are based on S4). For more information about speed and memory footprint, see `vignette("Performance")`.
+R6 classes are similar to R's reference classes but are smaller in size, and avoid some issues that come along with using S4 (R's reference classes are based on S4). For more information about speed and memory footprint, see `vignette("Performance")`.
 
 Unlike many objects in R, instances (objects) of R6 classes have reference semantics. R6 classes also support:
 
@@ -61,7 +61,7 @@ The `$new()` method creates the object and calls the `initialize()` method, if i
 
 Inside class methods, `self` refers to the object. Public members of the object (all you've seen so far) are accessed with `self$x`, and assignment is done with `self$x <- y`.
 
-Once the object is instantiated, you can access values and methods with `$`:
+Once the object is instantiated, you can access public fields and methods with `$`:
 
 ```{r}
 ann$hair
@@ -120,11 +120,9 @@ q$remove()
 
 However, private members can't be accessed directly:
 
-```{r eval = FALSE}
+```{r, error=TRUE}
 q$queue
-#> NULL
 q$length()
-#> Error: attempt to apply non-function
 ```
 
 A useful design pattern is for methods to return `self` (invisibly) when possible, because it makes them chainable. For example, the `add()` method returns `self` so you can chain them together:
@@ -180,13 +178,10 @@ n$x
 
 If the function takes no arguments, it's not possible to use it with `<-`:
 
-```{r eval=FALSE}
+```{r error=TRUE}
 n$rand
-#> [1] 0.2648
 n$rand
-#> [1] 2.171
 n$rand <- 3
-#> Error: unused argument (quote(3))
 ```
 
 Implementation note: Active bindings are bound in the public environment. The enclosing environment for these functions is also the public environment.
@@ -251,10 +246,30 @@ cq$remove()
 cq$get_total()
 ```
 
+Note that, unlike classical OOP in other languages (e.g. C++), R6 subclasses also have access to the private methods in superclass.
+
+For instance, in the following example, the `Duck` class has a private method `$quack()`, but its subcalss `Mallard` can access it using `super$quack()`.
+
+```{r}
+Duck <- R6Class("Duck",
+  private = list(quack = function() print("Quack Quack"))
+)
+
+Mallard <- R6Class("Mallard",
+  inherit = Duck,
+  public = list(quack = function() super$quack())
+)
+
+myMallard <- Mallard$new()
+myMallard$quack()
+```
+
 
 ### Fields containing reference objects
 
-If your R6 class contains any fields that also have reference semantics (e.g., other R6 objects, environments), those fields should be populated in the `initialize` method. If the field is set to the reference object directly in the class definition, that object will be shared across all instances of the R6 objects. Here's an example:
+If your R6 class contains any fields that also have reference semantics (e.g., other R6 objects, environments), those fields should be populated in the `initialize` method. If the field is set to the reference object directly in the class definition, that object will be shared across all instances of that R6 class. 
+
+Here's an example:
 
 ```{r}
 SimpleClass <- R6Class("SimpleClass",
@@ -314,7 +329,7 @@ Simple <- R6Class("Simple",
 
 Simple$set("public", "getx2", function() self$x*2)
 
-# To replace an existing member, use overwrite=TRUE
+# To replace an existing member, use `overwrite=TRUE`
 Simple$set("public", "x", 10, overwrite = TRUE)
 
 s <- Simple$new()
@@ -326,7 +341,7 @@ The new members will be present only in instances that are created after `$set()
 
 To prevent modification of a class, you can use `lock_class=TRUE` when creating the class. You can also lock and unlock a class as follows:
 
-```{r}
+```{r, error=TRUE}
 # Create a locked class
 Simple <- R6Class("Simple",
   public = list(
@@ -337,7 +352,7 @@ Simple <- R6Class("Simple",
 )
 
 # This would result in an error
-# Simple$set("public", "y", 2)
+Simple$set("public", "y", 2)
 
 # Unlock the class
 Simple$unlock()
@@ -352,7 +367,7 @@ Simple$lock()
 
 ### Cloning objects
 
-By default, R6 objects have method named `clone` for making a copy of the object.
+By default, R6 objects have a method named `$clone()` for making a copy of the object.
 
 ```{r}
 Simple <- R6Class("Simple",
@@ -403,9 +418,9 @@ If you don't want a `clone` method to be added, you can use `cloneable=FALSE` wh
 
 #### Deep cloning
 
-If there are any fields which are objects with reference semantics (environments, R6 objects, reference class objects), the copy will get a reference to the same object. This is sometimes desirable, but often it is not.
+If there are any fields that are objects with reference semantics (environments, R6 objects, reference class objects), the copy will get a reference to the same object. This is sometimes desirable, but often it is not.
 
-For example, we'll create an object `c1` which contains another R6 object, `s`, and then clone it. Because the original's and the clone's `s` fields both refer to the same object, modifying it from one results in a change that is reflect in the other.
+For example, we'll create an object `c1` which contains another R6 object, `s`, and then clone it. Because both the original and the clone object's `s` field refers to the same object, and modifying it from one results in a change that is reflected in the other.
 
 ```{r}
 Simple <- R6Class("Simple", public = list(x = 1))
@@ -427,7 +442,7 @@ c1$s$x <- 2
 c2$s$x
 ```
 
-To make it so the clone receives a *copy* of `s`, we can use the `deep=TRUE` option:
+To make sure that the clone receives a *copy* of `s`, we can use the `deep=TRUE` option:
 
 ```{r}
 c3 <- c1$clone(deep = TRUE)
@@ -439,7 +454,7 @@ c1$s$x <- 3
 c3$s$x
 ```
 
-The default behavior of `clone(deep=TRUE)` is to copy fields which are R6 objects, but not copy fields which are environments, reference class objects, or other data structures which contain other reference-type objects (for example, a list with an R6 object).
+The default behavior of `$clone(deep=TRUE)` is to copy fields that are R6 objects, but not to copy fields that are environments, reference class objects, or other data structures which contain other reference-type objects (for example, a list with an R6 object).
 
 If your R6 object contains these types of objects and you want to make a deep clone of them, you must provide your own function for deep cloning, in a private method named `deep_clone`. Below is an example of an R6 object with two fields, `a` and `b`, both of which which are environments, and both of which contain a value `x`. It also has a field `v` which is a regular (non-reference) value, and a private `deep_clone` method.
 
@@ -496,11 +511,37 @@ c2$v
 
 In the example `deep_clone` method above, we checked the name of each field to determine what to do with it, but we could also check the value, by using `inherits(value, "R6")`, or `is.environment()`, and so on.
 
+#### Cloning inheritance
+
+If a given R6 class is a subclass, the specified cloning behavior in this subclass will be overridden by that in the superclass.
+
+For example, let's create R6 class called `Creature`. Instances of this class can be cloned by setting `cloneable=TRUE`.
+
+```{r}
+Creature <- R6Class("Creature",
+  cloneable = TRUE
+)
+
+# cloning for class objects possible
+Creature$new()$clone()
+```
+
+If we now create R6 subclass `Human` that inherits from `Creature` class, even if we set `cloneable=FALSE`, cloning instances of this subclass will still be possible because the superclass allows cloning:
+
+```{r}
+Human <- R6Class("Human",
+  inherit = Creature,
+  cloneable = FALSE
+)
+
+# cloning still possible even when `cloneable` is set to `FALSE`
+Human$new()$clone()
+```
 
 ### Printing R6 objects to the screen
 
-R6 objects have a default `print` method that lists all members of the object.
-If a class defines a `print` method, then it overrides the default one.
+R6 objects have a default `$print()` method that lists all members of the object.
+If a class defines a `$print()` method, then it overrides the default one.
 
 ```{r}
 PrettyCountingQueue <- R6Class("PrettyCountingQueue",
@@ -520,7 +561,7 @@ pq
 
 ### Finalizers
 
-Sometimes it's useful to run a function when the object is garbage collected. For example, you may want to make sure a file or database connection gets closed. To do this, you can define a private `finalize()` method, which will be called with no arguments when the object is garbage collected.
+Sometimes it's useful to run a function when the object is garbage collected. For example, you may want to make sure a file or database connection gets closed. To do this, you can define a private `$finalize()` method, which will be called with no arguments when the object is garbage collected.
 
 
 ```{r}
@@ -539,7 +580,7 @@ obj <- A$new()
 rm(obj); gc()
 ```
 
-**NOTE:** In R6 version 2.3.0 (released 2018-10-04) and below, the `finalize` method could only be public. As of version 2.4.0, it can be public or private. Private is preferable because there's no reason a finalizer needs to be publicly accessible. If you use a private finalizer in an R package, you should set your R6 version dependency to `R6 (>= 2.4.0)`. In 2.6.0, R6 prints a message if a finalizer is public. In a future version, it will emit warnings, and finally it will no longer support public finalizers.
+**NOTE:** In R6 version 2.3.0 (released 2018-10-04) and below, the `finalize` method could only be public. As of version 2.4.0, it can be public or private. Private is preferable because there's no reason a finalizer needs to be publicly accessible. If you use a private finalizer in an R package, you should set your R6 version dependency to `R6 (>= 2.4.0)`. In 2.6.0, R6 prints a message if a finalizer is public. In a future version, it will emit warnings, and finally, it will no longer support public finalizers.
 
 Finalizers are implemented using the `reg.finalizer()` function, and they set `onexit=TRUE`, so that the finalizer will also be called when R exits. This is useful in some cases, like database connections.
 
@@ -548,11 +589,11 @@ Finalizers are implemented using the `reg.finalizer()` function, and they set `o
 
 When an R6 class definition contains functions in the public or private sections, those functions are *class methods*: they can access `self` (as well as `private` and `super` when available). When an R6 object is cloned, the resulting object's methods will have a `self` that refers to the new object. This works by changing the *enclosing environment* of the method in the cloned object.
 
-In contrast to class methods, you can also add regular functions as members of an R6 object. This can be done by assigning the function to a field in the `initialize` method, or after the object has been instantiated. These functions are not class methods, and they will not have access to `self`, `private`, or `super`.
+In contrast to class methods, you can also add regular functions as members of an R6 object. This can be done by assigning the function to a field in the `$initialize()` method, or after the object has been instantiated. These functions are not class methods, and they will not have access to `self`, `private`, or `super`.
 
-Here is a trivial class which has a method `get_self()` that simply returns `self`, as well as an empty member, `fn`. In this example, we'll assign a function to `fn` which has the same body as `get_self`. However, since it's a regular function, `self` will refer to something other than the R6 object:
+Here is a trivial class that has a method `$get_self()` that simply returns `self`, as well as an empty member, `fn`. In this example, we'll assign a function to `fn` with the same body as `get_self`. However, since it's a regular function, `self` will refer to something other than the R6 object:
 
-```R
+```{r}
 FunctionWrapper <- R6Class("FunctionWrapper",
   public = list(
     get_self = function() {
@@ -572,28 +613,16 @@ a$fn <- function() {
 }
 
 a$get_self()
-#> <FunctionWrapper>
-#>   Public:
-#>     clone: function (deep = FALSE)
-#>     fn: function ()
-#>     get_self: function ()
 
 a$fn()
-#> [1] 100
 ```
 
 As of R6 2.3.0, if the object is cloned, member (non-method) functions will not have their enclosing environment changed, which is what one would normally expect. It will behave this way:
 
-```R
+```{r}
 b <- a$clone()
 
 b$get_self()
-#> <FunctionWrapper>
-#>   Public:
-#>     clone: function (deep = FALSE)
-#>     fn: function ()
-#>     get_self: function ()
 
 b$fn()
-#> [1] 100
 ```

--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -542,7 +542,7 @@ Human <- R6Class("Human",
 Human$new()$clone()
 ```
 
-2. If the superclass has `cloneable = FALSE`, the `cloneable` property of the subclass will be respected.
+2. If the superclass has `cloneable=FALSE`, the `cloneable` property of the subclass will be respected.
 
 Let's use the same example as before but set `cloneable` to `FALSE` this time.
 

--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -516,63 +516,6 @@ c2$v
 
 In the example `deep_clone` method above, we checked the name of each field to determine what to do with it, but we could also check the value, by using `inherits(value, "R6")`, or `is.environment()`, and so on.
 
-#### Cloning inheritance
-
-If a given R6 class is a subclass, its cloning behavior will be contingent on the cloning behavior of its superclass. Specifically, there are two possibilities:
-
-1. If the superclass has `cloneable=TRUE`, no matter what subclass has set for `cloneable`, cloning will always work.
-
-For example, let's create R6 class called `Creature` with `cloneable` set to `TRUE`.
-
-```{r}
-Creature <- R6Class("Creature",
-  cloneable = TRUE
-)
-```
-
-If we now create R6 subclass `Human` that inherits from `Creature` class, even if we set `cloneable=FALSE`, cloning instances of this subclass will still be possible because the superclass allows cloning:
-
-```{r}
-Human <- R6Class("Human",
-  inherit = Creature,
-  cloneable = FALSE
-)
-
-# cloning still possible even when `cloneable` is set to `FALSE`
-Human$new()$clone()
-```
-
-2. If the superclass has `cloneable=FALSE`, the `cloneable` property of the subclass will be respected.
-
-Let's use the same example as before but set `cloneable` to `FALSE` this time.
-
-```{r}
-Creature <- R6Class("Creature",
-  cloneable = FALSE
-)
-```
-
-The subclass will now respect `cloneable` property of the subclass:
-
-```{r}
-Human <- R6Class("Human",
-  inherit = Creature,
-  cloneable = TRUE
-)
-
-Human$new()$clone()
-```
-
-```{r, eval=FALSE}
-Human <- R6Class("Human",
-  inherit = Creature,
-  cloneable = FALSE
-)
-
-Human$new()$clone()
-#> Error: attempt to apply non-function
-```
-
 ### Printing R6 objects to the screen
 
 R6 objects have a default `$print()` method that lists all members of the object.

--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -569,7 +569,7 @@ When an R6 class definition contains functions in the public or private sections
 
 In contrast to class methods, you can also add regular functions as members of an R6 object. This can be done by assigning the function to a field in the `$initialize()` method, or after the object has been instantiated. These functions are not class methods, and they will not have access to `self`, `private`, or `super`.
 
-Here is a trivial class that has a method `$get_self()` that simply returns `self`, as well as an empty member, `fn`. In this example, we'll assign a function to `fn` with the same body as `get_self`. However, since it's a regular function, `self` will refer to something other than the R6 object:
+Here is a trivial class which has a method `get_self()` that simply returns `self`, as well as an empty member, `fn`. In this example, we'll assign a function to `fn` which has the same body as `get_self`. However, since it's a regular function, `self` will refer to something other than the R6 object:
 
 ```{r}
 FunctionWrapper <- R6Class("FunctionWrapper",

--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -253,7 +253,7 @@ cq$get_total()
 
 Note that, unlike classical OOP in other languages (e.g. C++), R6 subclasses also have access to the private methods in superclass.
 
-For instance, in the following example, the `Duck` class has a private method `$quack()`, but its subcalss `Mallard` can access it using `super$quack()`.
+For instance, in the following example, the `Duck` class has a private method `$quack()`, but its subclass `Mallard` can access it using `super$quack()`.
 
 ```{r}
 Duck <- R6Class("Duck",
@@ -552,7 +552,7 @@ Creature <- R6Class("Creature",
 )
 ```
 
-Now, the sublass will respect `cloneable` property in the subclass:
+The subclass will now respect `cloneable` property of the subclass:
 
 ```{r}
 Human <- R6Class("Human",


### PR DESCRIPTION
- adds clarifications about inheritance and cloning
- ~~remove hard-coded chunk outputs using `error=TRUE` option in _knitr_~~
- consistently uses `$foo()` convention to refer to class methods
- grammatical changes