### PR TITLE
List articles in a meaningful order

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -12,7 +12,7 @@ development:
   mode: auto
 
 articles:
-- title: Working with R6
+- title: ~
   navbar: ~
   contents:
     - Introduction

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -10,3 +10,12 @@ template:
 
 development:
   mode: auto
+
+articles:
+- title: Working with R6
+  navbar: ~
+  contents:
+    - Introduction
+    - Portable
+    - Debugging
+    - Performance


### PR DESCRIPTION
Currently, they are listed alphabetically on the website, and it's not the order in which we should be encouraging users to read them.

![image](https://user-images.githubusercontent.com/11330453/161112287-7a45e261-b7ee-4485-b0ac-440180900f1e.png)

Happy to change the order if you have some other order in mind.