### PR TITLE
check also error messages in tests

### DIFF
--- a/tests/testthat/_snaps/clone.md
+++ b/tests/testthat/_snaps/clone.md
@@ -1,0 +1,40 @@
+# Can't use reserved name 'clone'
+
+    Cannot add a member with reserved name 'clone'.
+
+---
+
+    Cannot add a member with reserved name 'clone'.
+
+---
+
+    Cannot add a member with reserved name 'clone'.
+
+# Lock state
+
+    cannot add bindings to a locked environment
+
+---
+
+    cannot add bindings to a locked environment
+
+---
+
+    cannot add bindings to a locked environment
+
+---
+
+    cannot add bindings to a locked environment
+
+# Cloning with functions that are not methods
+
+    cannot change value of locked binding for 'method'
+
+---
+
+    cannot change value of locked binding for 'method'
+
+---
+
+    cannot change value of locked binding for 'method'
+

--- a/tests/testthat/_snaps/nonportable.md
+++ b/tests/testthat/_snaps/nonportable.md
@@ -1,0 +1,76 @@
+# initialization
+
+    Called new() with arguments, but there is no initialize method.
+
+# Private members are private, and self/private environments
+
+    attempt to apply non-function
+
+# Locking objects
+
+    cannot change value of locked binding for 'getx'
+
+---
+
+    cannot add bindings to a locked environment
+
+---
+
+    cannot add bindings to a locked environment
+
+---
+
+    cannot add bindings to a locked environment
+
+---
+
+    cannot change value of locked binding for 'getx'
+
+---
+
+    cannot change value of locked binding for 'gety'
+
+# Validity checks on creation
+
+    All elements of public, private, and active must be named.
+
+---
+
+    All elements of public, private, and active must be named.
+
+---
+
+    All elements of public, private, and active must be named.
+
+---
+
+    All items in public, private, and active must have unique names.
+
+---
+
+    All items in public, private, and active must have unique names.
+
+---
+
+    All items in public, private, and active must have unique names.
+
+---
+
+    Items cannot use reserved names 'self', 'private', and 'super'.
+
+---
+
+    Items cannot use reserved names 'self', 'private', and 'super'.
+
+---
+
+    Items cannot use reserved names 'self', 'private', and 'super'.
+
+---
+
+    'initialize' is not allowed in private or active.
+
+---
+
+    'initialize' is not allowed in private or active.
+

--- a/tests/testthat/_snaps/portable-inheritance.md
+++ b/tests/testthat/_snaps/portable-inheritance.md
@@ -1,0 +1,8 @@
+# sub and superclass must both be portable or non-portable
+
+    Sub and superclass must both be portable or non-portable.
+
+---
+
+    Sub and superclass must both be portable or non-portable.
+

--- a/tests/testthat/_snaps/portable.md
+++ b/tests/testthat/_snaps/portable.md
@@ -1,0 +1,32 @@
+# initialization
+
+    Called new() with arguments, but there is no initialize method.
+
+# Active bindings work
+
+    The requested value is not available.
+
+# Locking works
+
+    cannot change value of locked binding for 'getx'
+
+---
+
+    cannot add bindings to a locked environment
+
+---
+
+    cannot add bindings to a locked environment
+
+---
+
+    cannot add bindings to a locked environment
+
+---
+
+    cannot change value of locked binding for 'getx'
+
+---
+
+    cannot change value of locked binding for 'gety'
+

--- a/tests/testthat/_snaps/set.md
+++ b/tests/testthat/_snaps/set.md
@@ -1,0 +1,72 @@
+# Setting values set values on generator
+
+    Can't add x because it already present in AC generator.
+
+---
+
+    Can't add getxyz because it already present in AC generator.
+
+---
+
+    Can't add y because it already present in AC generator.
+
+---
+
+    Can't add z because it already present in AC generator.
+
+---
+
+    Can't add x2 because it already present in AC generator.
+
+---
+
+    Can't add x because it already present in AC generator.
+
+---
+
+    Can't add getxyz because it already present in AC generator.
+
+---
+
+    Can't add non-function to active
+
+---
+
+    Can't add z because it already present in AC generator.
+
+---
+
+    Can't add x2 because it already present in AC generator.
+
+---
+
+    Can't add x because it already present in AC generator.
+
+---
+
+    Can't add getxyz because it already present in AC generator.
+
+---
+
+    Can't add non-function to active
+
+---
+
+    Can't add z because it already present in AC generator.
+
+---
+
+    Can't add x2 because it already present in AC generator.
+
+# Locked class
+
+    Can't modify a locked R6 class.
+
+---
+
+    Can't modify a locked R6 class.
+
+---
+
+    Can't modify a locked R6 class.
+

--- a/tests/testthat/test-clone.R
+++ b/tests/testthat/test-clone.R
@@ -1,7 +1,7 @@
 test_that("Can't use reserved name 'clone'", {
-  expect_error(R6Class("AC", public = list(clone = function() NULL)))
-  expect_error(R6Class("AC", private = list(clone = function() NULL)))
-  expect_error(R6Class("AC", active = list(clone = function() NULL)))
+  expect_snapshot_error(R6Class("AC", public = list(clone = function() NULL)))
+  expect_snapshot_error(R6Class("AC", private = list(clone = function() NULL)))
+  expect_snapshot_error(R6Class("AC", active = list(clone = function() NULL)))
 })
 
 
@@ -387,13 +387,13 @@ test_that("Lock state", {
 
   a <- AC$new()
   b <- a$clone()
-  expect_error(a$z <- 1)
-  expect_error(b$z <- 1)
+  expect_snapshot_error(a$z <- 1)
+  expect_snapshot_error(b$z <- 1)
 
   expect_identical(a$yval(), NULL)
   expect_identical(b$yval(), NULL)
-  expect_error(a$yval(1))
-  expect_error(b$yval(1))
+  expect_snapshot_error(a$yval(1))
+  expect_snapshot_error(b$yval(1))
 
   # With lock = FALSE
   AC <- R6Class("AC",
@@ -1212,9 +1212,9 @@ test_that("Cloning with functions that are not methods", {
   expect_no_error(a$f <- identity)
   expect_no_error(a2$f <- identity)
   expect_no_error(a3$f <- identity)
-  expect_error(a$method <- identity)
-  expect_error(a2$method <- identity)
-  expect_error(a3$method <- identity)
+  expect_snapshot_error(a$method <- identity)
+  expect_snapshot_error(a2$method <- identity)
+  expect_snapshot_error(a3$method <- identity)
 
 
   # ==== With inheritance ====

--- a/tests/testthat/test-nonportable.R
+++ b/tests/testthat/test-nonportable.R
@@ -20,7 +20,7 @@ test_that("initialization", {
 
   # No initialize method: throw error if arguments are passed in
   AC <- R6Class("AC", portable = FALSE, public = list(x = 1))
-  expect_error(AC$new(3))
+  expect_snapshot_error(AC$new(3))
 })
 
 test_that("empty members and methods are allowed", {
@@ -61,7 +61,7 @@ test_that("Private members are private, and self/private environments", {
   # Behavioral tests
   expect_identical(A$x, 1)
   expect_null(A$y)
-  expect_error(A$getx_priv3())
+  expect_snapshot_error(A$getx_priv3())
   expect_identical(A$gety(), 2)  # Explicit access: private$y
   expect_identical(A$gety2(), 2) # Implicit access: y
   expect_identical(A$getx(), 1)  # Explicit access: self$x
@@ -111,12 +111,12 @@ test_that("Locking objects", {
   expect_identical(A$private$y, 5)
 
   # Can't modify methods
-  expect_error(A$getx <- function() 1)
-  expect_error(A$gety <- function() 2)
+  expect_snapshot_error(A$getx <- function() 1)
+  expect_snapshot_error(A$gety <- function() 2)
 
   # Can't add members
-  expect_error(A$z <- 1)
-  expect_error(A$private$z <- 1)
+  expect_snapshot_error(A$z <- 1)
+  expect_snapshot_error(A$private$z <- 1)
 
 
   # Not locked
@@ -135,8 +135,8 @@ test_that("Locking objects", {
   expect_identical(A$private$y, 5)
 
   # Can't modify methods
-  expect_error(A$getx <- function() 1)
-  expect_error(A$private$gety <- function() 2)
+  expect_snapshot_error(A$getx <- function() 1)
+  expect_snapshot_error(A$private$gety <- function() 2)
 
   # Can add members
   expect_no_error(A$z <- 1)
@@ -150,23 +150,23 @@ test_that("Validity checks on creation", {
   fun <- function() 1  # Dummy function for tests
 
   # All arguments must be named
-  expect_error(R6Class("AC", public = list(1)))
-  expect_error(R6Class("AC", private = list(1)))
-  expect_error(R6Class("AC", active = list(fun)))
+  expect_snapshot_error(R6Class("AC", public = list(1)))
+  expect_snapshot_error(R6Class("AC", private = list(1)))
+  expect_snapshot_error(R6Class("AC", active = list(fun)))
 
   # Names can't be duplicated
-  expect_error(R6Class("AC", public = list(a=1, a=2)))
-  expect_error(R6Class("AC", public = list(a=1), private = list(a=1)))
-  expect_error(R6Class("AC", private = list(a=1), active = list(a=fun)))
+  expect_snapshot_error(R6Class("AC", public = list(a=1, a=2)))
+  expect_snapshot_error(R6Class("AC", public = list(a=1), private = list(a=1)))
+  expect_snapshot_error(R6Class("AC", private = list(a=1), active = list(a=fun)))
 
   # Reserved names
-  expect_error(R6Class("AC", public = list(self = 1)))
-  expect_error(R6Class("AC", private = list(private = 1)))
-  expect_error(R6Class("AC", active = list(super = 1)))
+  expect_snapshot_error(R6Class("AC", public = list(self = 1)))
+  expect_snapshot_error(R6Class("AC", private = list(private = 1)))
+  expect_snapshot_error(R6Class("AC", active = list(super = 1)))
 
   # `initialize` only allowed in public
-  expect_error(R6Class("AC", private = list(initialize = fun)))
-  expect_error(R6Class("AC", active = list(initialize = fun)))
+  expect_snapshot_error(R6Class("AC", private = list(initialize = fun)))
+  expect_snapshot_error(R6Class("AC", active = list(initialize = fun)))
 })
 
 

--- a/tests/testthat/test-portable-inheritance.R
+++ b/tests/testthat/test-portable-inheritance.R
@@ -368,11 +368,11 @@ test_that("Inheritance hierarchy for super$ methods", {
 test_that("sub and superclass must both be portable or non-portable", {
   AC <- R6Class("AC", portable = FALSE, public = list(x=1))
   BC <- R6Class("BC", portable = TRUE, inherit = AC)
-  expect_error(BC$new())
+  expect_snapshot_error(BC$new())
 
   AC <- R6Class("AC", portable = TRUE, public = list(x=1))
   BC <- R6Class("BC", portable = FALSE, inherit = AC)
-  expect_error(BC$new())
+  expect_snapshot_error(BC$new())
 })
 
 

--- a/tests/testthat/test-portable.R
+++ b/tests/testthat/test-portable.R
@@ -20,7 +20,7 @@ test_that("initialization", {
 
   # No initialize method: throw error if arguments are passed in
   AC <- R6Class("AC", portable = TRUE, public = list(x = 1))
-  expect_error(AC$new(3))
+  expect_snapshot_error(AC$new(3))
 })
 
 
@@ -135,7 +135,7 @@ test_that("Active bindings work", {
   expect_identical(A$x, 30)
 
   A$x <- -2
-  expect_error(A$sqrt_of_x)
+  expect_snapshot_error(A$sqrt_of_x)
   # print does not throw an error trying to read
   # the active binding variables
   muted_print <- function(x) capture.output(print(x))
@@ -159,12 +159,12 @@ test_that("Locking works", {
   expect_identical(A$private$y, 5)
 
   # Can't modify methods
-  expect_error(A$getx <- function() 1)
-  expect_error(A$gety <- function() 2)
+  expect_snapshot_error(A$getx <- function() 1)
+  expect_snapshot_error(A$gety <- function() 2)
 
   # Can't add members
-  expect_error(A$z <- 1)
-  expect_error(A$private$z <- 1)
+  expect_snapshot_error(A$z <- 1)
+  expect_snapshot_error(A$private$z <- 1)
 
 
   # Not locked
@@ -183,8 +183,8 @@ test_that("Locking works", {
   expect_identical(A$private$y, 5)
 
   # Can't modify methods
-  expect_error(A$getx <- function() 1)
-  expect_error(A$private$gety <- function() 2)
+  expect_snapshot_error(A$getx <- function() 1)
+  expect_snapshot_error(A$private$gety <- function() 2)
 
   # Can add members
   expect_no_error(A$z <- 1)

--- a/tests/testthat/test-set.R
+++ b/tests/testthat/test-set.R
@@ -33,18 +33,18 @@ test_that("Setting values set values on generator", {
 
 
   # Can't set existing names
-  expect_error(AC$set("public", "x", 99))
-  expect_error(AC$set("public", "getxyz", function() 99))
-  expect_error(AC$set("private", "y", 99))
-  expect_error(AC$set("private", "z", function() 99))
-  expect_error(AC$set("active", "x2", function(value) 99))
+  expect_snapshot_error(AC$set("public", "x", 99))
+  expect_snapshot_error(AC$set("public", "getxyz", function() 99))
+  expect_snapshot_error(AC$set("private", "y", 99))
+  expect_snapshot_error(AC$set("private", "z", function() 99))
+  expect_snapshot_error(AC$set("active", "x2", function(value) 99))
 
   # Can't set existing names in different group
-  expect_error(AC$set("private", "x", 99))
-  expect_error(AC$set("private", "getxyz", function() 99))
-  expect_error(AC$set("active", "y", 99))
-  expect_error(AC$set("public", "z", function() 99))
-  expect_error(AC$set("private", "x2", function(value) 99))
+  expect_snapshot_error(AC$set("private", "x", 99))
+  expect_snapshot_error(AC$set("private", "getxyz", function() 99))
+  expect_snapshot_error(AC$set("active", "y", 99))
+  expect_snapshot_error(AC$set("public", "z", function() 99))
+  expect_snapshot_error(AC$set("private", "x2", function(value) 99))
 
   # Can set existing names if overwrite = TRUE
   AC$set("public", "x", 99, overwrite = TRUE)
@@ -54,11 +54,11 @@ test_that("Setting values set values on generator", {
   AC$set("active", "x2", function(value) 99, overwrite = TRUE)
 
   # Can't set existing names in different group, even if overwrite = TRUE
-  expect_error(AC$set("private", "x", 99, overwrite = TRUE))
-  expect_error(AC$set("private", "getxyz", function() 99, overwrite = TRUE))
-  expect_error(AC$set("active", "y", 99, overwrite = TRUE))
-  expect_error(AC$set("public", "z", function() 99, overwrite = TRUE))
-  expect_error(AC$set("private", "x2", function(value) 99, overwrite = TRUE))
+  expect_snapshot_error(AC$set("private", "x", 99, overwrite = TRUE))
+  expect_snapshot_error(AC$set("private", "getxyz", function() 99, overwrite = TRUE))
+  expect_snapshot_error(AC$set("active", "y", 99, overwrite = TRUE))
+  expect_snapshot_error(AC$set("public", "z", function() 99, overwrite = TRUE))
+  expect_snapshot_error(AC$set("private", "x2", function(value) 99, overwrite = TRUE))
 })
 
 
@@ -78,15 +78,15 @@ test_that("Setting values with empty public or private", {
 
 test_that("Locked class", {
   AC <- R6Class("AC", lock_class = TRUE)
-  expect_error(AC$set("public", "x", 1))
-  expect_error(AC$set("private", "x", 1))
+  expect_snapshot_error(AC$set("public", "x", 1))
+  expect_snapshot_error(AC$set("private", "x", 1))
 
   expect_true(AC$is_locked())
   AC$unlock()
   expect_false(AC$is_locked())
   AC$set("public", "x", 1)
   AC$lock()
-  expect_error(AC$set("public", "x", 2))
+  expect_snapshot_error(AC$set("public", "x", 2))
 })
 
 test_that("Assigning NULL values", {


### PR DESCRIPTION
Currently, tests are only testing if the errors occur, but additionally capturing the error message assures us that the error was produced for _expected_ reasons, and not for some other, unexpected reasons. 