### PR TITLE
Fix cloning inheritance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ R6 2.5.1.9000
 
 * `R6Class()` now prints a message when a `finalize` method is public instead of private.
 
-* When subclass' `cloneable` property differs from superclass', the former will override the latter (@IndrajeetPatil, #247).
+* When subclass allows cloning, while superclass has turned cloning off, superclass will override subclass' cloning properties. (@IndrajeetPatil, #247).
 
 R6 2.5.1
 ========

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ R6 2.5.1.9000
 
 * `R6Class()` now prints a message when a `finalize` method is public instead of private.
 
+* When subclass' `cloneable` property differs from superclass', the former will override the latter (@IndrajeetPatil, #247).
+
 R6 2.5.1
 ========
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ R6 2.5.1.9000
 
 * `R6Class()` now prints a message when a `finalize` method is public instead of private.
 
-* When subclass allows cloning, while superclass has turned cloning off, superclass will override subclass' cloning properties. (@IndrajeetPatil, #247).
+* When a superclass is not cloneable, then subclasses cannot be cloneable (@IndrajeetPatil, #247).
 
 R6 2.5.1
 ========

--- a/R/new.R
+++ b/R/new.R
@@ -19,13 +19,11 @@ generator_funs$new <- function(...) {
     if (!identical(cloneable, inherit$cloneable)) {
       if (inherit$cloneable) {
         inherit[["public_methods"]][["clone"]] <- NULL
-      }
-
-      if (!inherit$cloneable) {
-        message(c(
-          "Subclass wants to allow cloning, but superclass has turned it off. ",
-          "Therefore, cloning will also be turned off for subclass."
-        ))
+      } else {
+        message(
+          "Superclass ", get_superclassnames(inherit), " has cloneable=FALSE, but subclass ", classname, " has cloneable=TRUE. ",
+          "A subclass cannot be cloneable when its superclass is not cloneable, so cloning will be disabled for ", classname, "."
+        )
 
         public_methods[["clone"]] <- NULL
       }

--- a/R/new.R
+++ b/R/new.R
@@ -13,6 +13,15 @@ generator_funs$new <- function(...) {
     if (!identical(portable, inherit$portable))
       stop("Sub and superclass must both be portable or non-portable.")
 
+    if (!identical(cloneable, inherit$cloneable)) {
+      message(c(
+        "Sub and superclass have different cloneable properties. ",
+        "Subclass property will override superclass property."
+      ))
+
+      inherit[["public_methods"]][["clone"]] <- NULL
+    }
+
     # Merge fields over superclass fields, recursively --------------
     recursive_merge <- function(obj, which) {
       if (is.null(obj)) return(NULL)
@@ -91,12 +100,10 @@ generator_funs$new <- function(...) {
     if (portable) {
       # Set up the superclass objects
       super_struct <- create_super_env(inherit, public_bind_env,
-                                       private_bind_env, portable = TRUE,
-                                       cloneable = cloneable)
+                                       private_bind_env, portable = TRUE)
     } else {
       # Set up the superclass objects
-      super_struct <- create_super_env(inherit, public_bind_env, portable = FALSE,
-                                       cloneable = cloneable)
+      super_struct <- create_super_env(inherit, public_bind_env, portable = FALSE)
     }
 
     enclos_env$super <- super_struct$bind_env
@@ -201,7 +208,7 @@ encapsulate({
   # recursing early on in the function, and then fill the methods downward by
   # doing the work for each level and passing the needed information down.
   create_super_env <- function(inherit, public_bind_env, private_bind_env = NULL,
-                               portable = TRUE, cloneable = TRUE) {
+                               portable = TRUE) {
     public_methods  <- inherit$public_methods
     private_methods <- inherit$private_methods
     active          <- inherit$active
@@ -247,7 +254,7 @@ encapsulate({
     inherit_inherit <- inherit$get_inherit()
     if (!is.null(inherit_inherit)) {
       super_struct <- create_super_env(inherit_inherit, public_bind_env,
-                                       private_bind_env, portable, cloneable)
+                                       private_bind_env, portable)
       super_enclos_env$super <- super_struct$bind_env
 
       # Merge this level's methods over the superclass methods

--- a/R/new.R
+++ b/R/new.R
@@ -13,22 +13,6 @@ generator_funs$new <- function(...) {
     if (!identical(portable, inherit$portable))
       stop("Sub and superclass must both be portable or non-portable.")
 
-    # If `cloneable` property differs between sub and superclass
-    # - super will override sub if super doesn't allow cloning
-    # - sub will override super if super allows cloning
-    if (!identical(cloneable, inherit$cloneable)) {
-      if (inherit$cloneable) {
-        inherit[["public_methods"]][["clone"]] <- NULL
-      } else {
-        message(
-          "Superclass ", get_superclassnames(inherit), " has cloneable=FALSE, but subclass ", classname, " has cloneable=TRUE. ",
-          "A subclass cannot be cloneable when its superclass is not cloneable, so cloning will be disabled for ", classname, "."
-        )
-
-        public_methods[["clone"]] <- NULL
-      }
-    }
-
     # Merge fields over superclass fields, recursively --------------
     recursive_merge <- function(obj, which) {
       if (is.null(obj)) return(NULL)
@@ -119,6 +103,20 @@ generator_funs$new <- function(...) {
     public_methods  <- merge_vectors(super_struct$public_methods, public_methods)
     private_methods <- merge_vectors(super_struct$private_methods, private_methods)
     active          <- merge_vectors(super_struct$active, active)
+
+    # If `cloneable` property differs between sub and superclass
+    # - super will override sub if super doesn't allow cloning
+    # - sub will override super if super allows cloning
+    if (!identical(cloneable, inherit$cloneable)) {
+      public_methods[["clone"]] <- NULL
+
+      if (!inherit$cloneable) {
+        message(
+          "Superclass ", get_superclassnames(inherit), " has cloneable=FALSE, but subclass ", classname, " has cloneable=TRUE. ",
+          "A subclass cannot be cloneable when its superclass is not cloneable, so cloning will be disabled for ", classname, "."
+        )
+      }
+    }
   }
 
   # Copy objects to public bind environment -------------------------

--- a/R/new.R
+++ b/R/new.R
@@ -112,7 +112,7 @@ generator_funs$new <- function(...) {
 
       if (!inherit$cloneable) {
         message(
-          "Superclass ", get_superclassnames(inherit), " has cloneable=FALSE, but subclass ", classname, " has cloneable=TRUE. ",
+          "Superclass ", inherit$classname, " has cloneable=FALSE, but subclass ", classname, " has cloneable=TRUE. ",
           "A subclass cannot be cloneable when its superclass is not cloneable, so cloning will be disabled for ", classname, "."
         )
       }

--- a/R/new.R
+++ b/R/new.R
@@ -13,13 +13,22 @@ generator_funs$new <- function(...) {
     if (!identical(portable, inherit$portable))
       stop("Sub and superclass must both be portable or non-portable.")
 
+    # If `cloneable` property differs between sub and superclass
+    # - super will override sub if super doesn't allow cloning
+    # - sub will override super if super allows cloning
     if (!identical(cloneable, inherit$cloneable)) {
-      message(c(
-        "Sub and superclass have different cloneable properties. ",
-        "Subclass property will override superclass property."
-      ))
+      if (inherit$cloneable) {
+        inherit[["public_methods"]][["clone"]] <- NULL
+      }
 
-      inherit[["public_methods"]][["clone"]] <- NULL
+      if (!inherit$cloneable) {
+        message(c(
+          "Subclass wants to allow cloning, but superclass has turned it off. ",
+          "Therefore, cloning will also be turned off for subclass."
+        ))
+
+        public_methods[["clone"]] <- NULL
+      }
     }
 
     # Merge fields over superclass fields, recursively --------------

--- a/tests/testthat/test-cloning-inheritance.R
+++ b/tests/testthat/test-cloning-inheritance.R
@@ -1,6 +1,4 @@
 test_that("Subclass can override superclass' cloneable property", {
-  msg <- "Sub and superclass have different cloneable properties."
-
   # superclass cloneable ---------------------
 
   Creature <- R6Class("Creature", cloneable = TRUE)
@@ -10,7 +8,7 @@ test_that("Subclass can override superclass' cloneable property", {
   expect_s3_class(sheep$clone(), "Sheep")
 
   Human <- R6Class("Human", inherit = Creature, cloneable = FALSE)
-  expect_message(human <- Human$new(), msg)
+  expect_message(human <- Human$new(), NA)
   expect_error(human$clone(), "attempt to apply non-function")
 
   # superclass non-cloneable  ---------------------
@@ -18,8 +16,8 @@ test_that("Subclass can override superclass' cloneable property", {
   Creature <- R6Class("Creature", cloneable = FALSE)
 
   Sheep <- R6Class("Sheep", inherit = Creature, cloneable = TRUE)
-  expect_message(sheep <- Sheep$new(), msg)
-  expect_s3_class(sheep$clone(), "Sheep")
+  expect_message(sheep <- Sheep$new(), "Subclass wants to allow cloning, but superclass has turned it off.")
+  expect_error(sheep$clone(), "attempt to apply non-function")
 
   Human <- R6Class("Human", inherit = Creature, cloneable = FALSE)
   expect_message(human <- Human$new(), NA)

--- a/tests/testthat/test-cloning-inheritance.R
+++ b/tests/testthat/test-cloning-inheritance.R
@@ -6,7 +6,7 @@ test_that("Subclass can override superclass' cloneable property", {
   Creature <- R6Class("Creature", cloneable = TRUE)
 
   Sheep <- R6Class("Sheep", inherit = Creature, cloneable = TRUE)
-  sheep <- Sheep$new()
+  expect_message(sheep <- Sheep$new(), NA)
   expect_s3_class(sheep$clone(), "Sheep")
 
   Human <- R6Class("Human", inherit = Creature, cloneable = FALSE)
@@ -22,6 +22,6 @@ test_that("Subclass can override superclass' cloneable property", {
   expect_s3_class(sheep$clone(), "Sheep")
 
   Human <- R6Class("Human", inherit = Creature, cloneable = FALSE)
-  human <- Human$new()
+  expect_message(human <- Human$new(), NA)
   expect_error(human$clone(), "attempt to apply non-function")
 })

--- a/tests/testthat/test-cloning-inheritance.R
+++ b/tests/testthat/test-cloning-inheritance.R
@@ -20,6 +20,7 @@ test_that("Subclass can override superclass' cloneable property", {
   Sheep <- R6Class("Sheep", inherit = Creature, cloneable = TRUE)
   expect_message(sheep <- Sheep$new(), "Superclass Creature has cloneable=FALSE, but subclass Sheep has cloneable=TRUE.")
   expect_error(sheep$clone(), "attempt to apply non-function")
+  # Make sure that the superclass wasn't inadvertantly modified.
   expect_false("clone" %in% names(Creature$public_methods))
 
   Human <- R6Class("Human", inherit = Creature, cloneable = FALSE)

--- a/tests/testthat/test-cloning-inheritance.R
+++ b/tests/testthat/test-cloning-inheritance.R
@@ -6,20 +6,24 @@ test_that("Subclass can override superclass' cloneable property", {
   Sheep <- R6Class("Sheep", inherit = Creature, cloneable = TRUE)
   expect_message(sheep <- Sheep$new(), NA)
   expect_s3_class(sheep$clone(), "Sheep")
+  expect_true("clone" %in% names(Creature$public_methods))
 
   Human <- R6Class("Human", inherit = Creature, cloneable = FALSE)
   expect_message(human <- Human$new(), NA)
   expect_error(human$clone(), "attempt to apply non-function")
+  expect_true("clone" %in% names(Creature$public_methods))
 
   # superclass non-cloneable  ---------------------
 
   Creature <- R6Class("Creature", cloneable = FALSE)
 
   Sheep <- R6Class("Sheep", inherit = Creature, cloneable = TRUE)
-  expect_message(sheep <- Sheep$new(), "Subclass wants to allow cloning, but superclass has turned it off.")
+  expect_message(sheep <- Sheep$new(), "Superclass Creature has cloneable=FALSE, but subclass Sheep has cloneable=TRUE.")
   expect_error(sheep$clone(), "attempt to apply non-function")
+  expect_false("clone" %in% names(Creature$public_methods))
 
   Human <- R6Class("Human", inherit = Creature, cloneable = FALSE)
   expect_message(human <- Human$new(), NA)
   expect_error(human$clone(), "attempt to apply non-function")
+  expect_false("clone" %in% names(Creature$public_methods))
 })

--- a/tests/testthat/test-cloning-inheritance.R
+++ b/tests/testthat/test-cloning-inheritance.R
@@ -1,0 +1,27 @@
+test_that("Subclass can override superclass' cloneable property", {
+  msg <- "Sub and superclass have different cloneable properties."
+
+  # superclass cloneable ---------------------
+
+  Creature <- R6Class("Creature", cloneable = TRUE)
+
+  Sheep <- R6Class("Sheep", inherit = Creature, cloneable = TRUE)
+  sheep <- Sheep$new()
+  expect_s3_class(sheep$clone(), "Sheep")
+
+  Human <- R6Class("Human", inherit = Creature, cloneable = FALSE)
+  expect_message(human <- Human$new(), msg)
+  expect_error(human$clone(), "attempt to apply non-function")
+
+  # superclass non-cloneable  ---------------------
+
+  Creature <- R6Class("Creature", cloneable = FALSE)
+
+  Sheep <- R6Class("Sheep", inherit = Creature, cloneable = TRUE)
+  expect_message(sheep <- Sheep$new(), msg)
+  expect_s3_class(sheep$clone(), "Sheep")
+
+  Human <- R6Class("Human", inherit = Creature, cloneable = FALSE)
+  human <- Human$new()
+  expect_error(human$clone(), "attempt to apply non-function")
+})


### PR DESCRIPTION
Closes #247
Closes #165

## Example

``` r
library(R6)

Creature <- R6Class("Creature", cloneable = TRUE)

Sheep <- R6Class("Sheep", inherit = Creature, cloneable = TRUE)
sheep <- Sheep$new()
class(sheep$clone())
#> [1] "Sheep"    "Creature" "R6"

Human <- R6Class("Human", inherit = Creature, cloneable = FALSE)
human <- Human$new()
human$clone()
#> Error in eval(expr, envir, enclos): attempt to apply non-function

Creature <- R6Class("Creature", cloneable = FALSE)

Sheep <- R6Class("Sheep", inherit = Creature, cloneable = TRUE)
sheep <- Sheep$new()
#> Subclass wants to allow cloning, but superclass has turned it off. Therefore, cloning will also be turned off for subclass.
class(sheep$clone())
#> Error in eval(expr, envir, enclos): attempt to apply non-function

Human <- R6Class("Human", inherit = Creature, cloneable = FALSE)
human <- Human$new()
human$clone()
#> Error in eval(expr, envir, enclos): attempt to apply non-function
```

<sup>Created on 2022-10-27 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>