### PR TITLE
Avoid using `$` on environments that may not be R6 objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ License: MIT + file LICENSE
 URL: https://r6.r-lib.org, https://github.com/r-lib/R6/
 BugReports: https://github.com/r-lib/R6/issues
 Depends:
-    R (>= 3.0)
+    R (>= 3.2)
 Suggests:
     lobstr,
     testthat (>= 3.0.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,4 @@ Suggests:
 Config/Needs/website: tidyverse/tidytemplate, ggplot2, microbenchmark, scales
 Config/testthat/edition: 3
 Encoding: UTF-8
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,8 @@ R6 2.5.1.9000
 
 * When a superclass is not cloneable, then subclasses cannot be cloneable (@IndrajeetPatil, #247).
 
-* Fix using `$.__enclos_env__` on arbitrary environments while deep cloning (@zeehio, #253)
+* Fix using `$.__enclos_env__` on arbitrary environments while deep cloning.
+  R6 now requires R >= 3.2. (@zeehio, #253)
 
 R6 2.5.1
 ========

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ R6 2.5.1.9000
 
 * When a superclass is not cloneable, then subclasses cannot be cloneable (@IndrajeetPatil, #247).
 
+* Fix using `$.__enclos_env__` on arbitrary environments while deep cloning (@zeehio, #253)
+
 R6 2.5.1
 ========
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,8 +7,7 @@ R6 2.5.1.9000
 
 * When a superclass is not cloneable, then subclasses cannot be cloneable (@IndrajeetPatil, #247).
 
-* Fix using `$.__enclos_env__` on arbitrary environments while deep cloning.
-  R6 now requires R >= 3.2. (@zeehio, #253)
+* Fixed #253: Errors could occur when deep cloning if a member object was an environment with a class that had a `$` method. Deep cloning now uses `get0()` instead of `$`. R6 now requires R >= 3.2. (@zeehio, #274)
 
 R6 2.5.1
 ========

--- a/R/clone.R
+++ b/R/clone.R
@@ -89,11 +89,9 @@ generator_funs$clone_method <- function(deep = FALSE) {
       # fields that are R6 objects.
       deep_clone <- function(name, value) {
         # Check if it's an R6 object.
-        if (
-          is.environment(value) &&
-          ".__enclos_env__" %in% ls(value, all.names = TRUE) &&
-          !is.null(get(".__enclos_env__", value))
-        ) {
+        is_r6_object <- is.environment(value) &&
+          !is.null(get0(".__enclos_env__", value, inherits = FALSE))
+        if (is_r6_object) {
           return(value$clone(deep = TRUE))
         }
         value

--- a/R/clone.R
+++ b/R/clone.R
@@ -89,7 +89,11 @@ generator_funs$clone_method <- function(deep = FALSE) {
       # fields that are R6 objects.
       deep_clone <- function(name, value) {
         # Check if it's an R6 object.
-        if (is.environment(value) && !is.null(value$`.__enclos_env__`)) {
+        if (
+          is.environment(value) &&
+          ".__enclos_env__" %in% ls(value, all.names = TRUE) &&
+          !is.null(get(".__enclos_env__", value))
+        ) {
           return(value$clone(deep = TRUE))
         }
         value

--- a/tests/testthat/test-clone.R
+++ b/tests/testthat/test-clone.R
@@ -1077,7 +1077,7 @@ test_that("Cloning inherited methods for non-portable classes", {
   expect_identical(a$x, 3)
 })
 
-test_that("Unknown environments are not copied nor $-inspected", {
+test_that("In deep_clone(), don't try to clone non-R6 objects", {
 
   `$.asdfasdf` <- function(x, value) {
     stop("error")

--- a/tests/testthat/test-clone.R
+++ b/tests/testthat/test-clone.R
@@ -1077,6 +1077,28 @@ test_that("Cloning inherited methods for non-portable classes", {
   expect_identical(a$x, 3)
 })
 
+test_that("Unknown environments are not copied nor $-inspected", {
+
+  `$.asdfasdf` <- function(x, value) {
+    stop("error")
+  }
+
+  bar <- R6Class("bar",
+                 public = list(
+                   x = NULL,
+                   initialize = function() {
+                     x <- new.env(parent = emptyenv())
+                     class(x) <- "asdfasdf"
+                     self$x <- x
+                     x
+                   }
+                 )
+  )
+
+  obj <- bar$new()
+  obj2 <- obj$clone(deep = TRUE)
+  expect_equal(obj$x, obj2$x)
+})
 
 test_that("Deep cloning", {
   AC <- R6Class("AC", public = list(x = 1))

--- a/tests/testthat/test-clone.R
+++ b/tests/testthat/test-clone.R
@@ -1079,25 +1079,24 @@ test_that("Cloning inherited methods for non-portable classes", {
 
 test_that("In deep_clone(), don't try to clone non-R6 objects", {
 
-  `$.asdfasdf` <- function(x, value) {
+  `$.test` <- function(x, value) {
     stop("error")
   }
 
-  bar <- R6Class("bar",
-                 public = list(
-                   x = NULL,
-                   initialize = function() {
-                     x <- new.env(parent = emptyenv())
-                     class(x) <- "asdfasdf"
-                     self$x <- x
-                     x
-                   }
-                 )
+  AC <- R6Class("AC",
+    public = list(
+      x = NULL,
+      initialize = function() {
+        x <- new.env(parent = emptyenv())
+        class(x) <- "test"
+        self$x <- x
+      }
+    )
   )
 
-  obj <- bar$new()
+  obj <- AC$new()
   obj2 <- obj$clone(deep = TRUE)
-  expect_equal(obj$x, obj2$x)
+  expect_identical(obj$x, obj2$x)
 })
 
 test_that("Deep cloning", {


### PR DESCRIPTION
Avoids using `$` on environments we don't control, because unexpected things may happen (such as #253). 

- Closes #253