### PR TITLE
Avoid use of `NextMethod()` in `.DollarNames.R6()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+R6 2.6.0.9000
+=============
+
+* Closed #298: In `.DollarNames.R6()`, avoid use of `NextMethod()`. This is to work around a compatibility issue with RStudio IDE. (#299)
+
+
 R6 2.6.0
 ========
 

--- a/R/r6_class.R
+++ b/R/r6_class.R
@@ -544,6 +544,7 @@ R6Class <- encapsulate(function(classname = NULL, public = list(),
 
 #' @exportS3Method utils::.DollarNames
 .DollarNames.R6 <- function(x, pattern) {
-  names <- NextMethod()
-  names <- setdiff(names, c(".__enclos_env__", "initialize"))
+  names <- ls(x, all.names = TRUE)
+  names <- names[grepl(pattern, names)]
+  setdiff(names, c(".__enclos_env__", "initialize"))
 }

--- a/tests/testthat/test-dollarnames.R
+++ b/tests/testthat/test-dollarnames.R
@@ -1,0 +1,28 @@
+test_that(".DollarNames works as expected", {
+  AC <- R6Class("AC",
+    public = list(
+      x = 1,
+      .y = 1
+    ),
+    private = list(
+      px = 1,
+      .py = 1
+    ),
+    active = list(
+      ax = function(value) 1,
+      .ay = function(value) 1
+    )
+  )
+
+  a <- AC$new()
+  expected_names <- c("x", ".y", "ax", ".ay", "clone")
+  expect_setequal(.DollarNames(a, ""), expected_names)
+  expect_setequal(utils:::.DollarNames(a, ""), expected_names)
+
+  # Tests for direct calling of .DollarNames.R6 without S3 dispatch
+  # https://github.com/rstudio/rstudio/issue/15706
+  # https://github.com/rstudio/rstudio/pull/15707
+  expect_setequal(R6:::.DollarNames.R6(a, ""), expected_names)
+  DollarNamesR6 <- R6:::.DollarNames.R6
+  expect_setequal(DollarNamesR6(a, ""), expected_names)
+})


### PR DESCRIPTION
Fixes #298.

In the RStudio IDE prior to [this PR](https://github.com/rstudio/rstudio/pull/15707), it essentially called `.DollarNames.R6` directly, and so the call to `NextMethod()` would throw an error.

This PR makes it so we avoid `NextMethod()` entirely.